### PR TITLE
fix: setProviderStatus for plugins

### DIFF
--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -461,7 +461,7 @@ module.exports = (theApp: any) => {
       registerDeltaInputHandler: (handler: any) => {
         onStopHandlers[plugin.id].push(app.registerDeltaInputHandler(handler))
       },
-      setPluginStatus: (msg: string) => {
+      setProviderStatus: (msg: string) => {
         app.setPluginStatus(plugin.id, msg)
       },
       setProviderError: (msg: string) => {


### PR DESCRIPTION
app.setProviderStatus was accidentally renamed app.setPluginStatus
in plugin api, which exposed the real app.setProviderStatus where
the first parameter is the id, not the message.