### PR TITLE
feat: add CA support for server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ logs/*
 bower_components
 settings/ssl-key.pem
 settings/ssl-cert.pem
+settings/ssl-ca-key.pem
+settings/ssl-ca-cert.pem
 /*.iml
 
 *.tgz
@@ -22,11 +24,15 @@ test/plugin-test-config/.npmrc
 test/plugin-test-config/plugin-config-data/
 test/plugin-test-config/ssl-cert.pem
 test/plugin-test-config/ssl-key.pem
+test/plugin-test-config/ssl-ca-cert.pem
+test/plugin-test-config/ssl-ca-key.pem
 test/plugin-test-config/baseDeltas.json
 
 test/server-test-config/applicationData/
 test/server-test-config/ssl-cert.pem
 test/server-test-config/ssl-key.pem
+test/server-test-config/ssl-ca-cert.pem
+test/server-test-config/ssl-ca-key.pem
 test/server-test-config/plugin-config-data/
 
 docs/built

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "ms": "^2.1.2",
     "ncp": "^2.0.0",
     "primus": "^7.0.0",
-    "selfsigned": "^2.4.1",
+    "selfsigned": "^5.2.0",
     "semver": "^7.5.4",
     "split": "^1.0.0",
     "stat-mode": "^1.0.0",


### PR DESCRIPTION
- Upgrade selfsigned package to v5.2.0 with CA capabilities
- Generate CA certificate that signs server certificates
- Server certificates are now CA-signed instead of self-signed
- Store CA key and cert separately (ssl-ca-key.pem, ssl-ca-cert.pem)
- Add CA files to .gitignore to prevent accidental commits