### PR TITLE
wsDevicesWithNamesAll (#22)

### DIFF
--- a/packages/server-admin-ui/src/utils/wsDeviceUtils.js
+++ b/packages/server-admin-ui/src/utils/wsDeviceUtils.js
@@ -1,0 +1,112 @@
+/**
+ * Utility functions for WebSocket device name resolution
+ *
+ * WS device IDs have the format "ws.{clientId}" where the clientId
+ * may have dots replaced with underscores. These IDs are not
+ * user-friendly, so we provide utilities to resolve them to
+ * human-readable device descriptions when available.
+ *
+ * Note: Delta $source can be composite like "ws.device_id.nmea0183.GGA"
+ * where the device part is followed by additional source path info.
+ */
+
+/**
+ * Converts a device clientId to the format used in WS source IDs
+ * by replacing dots with underscores.
+ *
+ * @param {string} clientId - The device clientId (e.g., "my.device.id")
+ * @returns {string} The WS format (e.g., "my_device_id")
+ */
+export function clientIdToWsFormat(clientId) {
+  if (!clientId) return ''
+  return clientId.replace(/\./g, '_')
+}
+
+/**
+ * Finds a device that matches the given WS source ID.
+ * The source ID may be composite (e.g., "ws.device_id.nmea0183.GGA")
+ * so we check if any device's clientId matches as a prefix.
+ *
+ * @param {string} wsSourceId - The WS source ID (e.g., "ws.device_id" or "ws.device_id.path.info")
+ * @param {Array} devices - Array of device objects with clientId property
+ * @returns {Object|null} The matching device or null
+ */
+export function findDeviceByWsSource(wsSourceId, devices) {
+  if (!wsSourceId || !wsSourceId.startsWith('ws.') || !devices || !Array.isArray(devices)) {
+    return null
+  }
+
+  // Get the part after "ws."
+  const sourceWithoutPrefix = wsSourceId.slice(3)
+
+  // Find a device whose clientId (in ws format) matches the start of the source
+  for (const device of devices) {
+    if (device && device.clientId) {
+      const wsFormatClientId = clientIdToWsFormat(device.clientId)
+      // Check if source starts with this device's ID
+      // Must be exact match or followed by a dot (to avoid partial matches)
+      if (
+        sourceWithoutPrefix === wsFormatClientId ||
+        sourceWithoutPrefix.startsWith(wsFormatClientId + '.')
+      ) {
+        return device
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Gets the display name for a WebSocket source ID.
+ * Returns the device description if available, otherwise the original ID.
+ *
+ * @param {string} wsSourceId - The WebSocket source ID (e.g., "ws.device_id" or "ws.device_id.path")
+ * @param {Array} devices - Array of device objects with clientId and description
+ * @returns {string} The display name (description or original ID)
+ */
+export function getWsDeviceDisplayName(wsSourceId, devices) {
+  if (!wsSourceId || !wsSourceId.startsWith('ws.')) {
+    return wsSourceId
+  }
+
+  const device = findDeviceByWsSource(wsSourceId, devices)
+
+  // Return description if it exists and is not empty
+  if (device && device.description && device.description.trim() !== '') {
+    return device.description
+  }
+
+  return wsSourceId
+}
+
+/**
+ * Gets the display name for any source ID, handling both WS and non-WS sources.
+ * For WS sources, attempts to resolve to device description.
+ * For non-WS sources, returns the ID as-is.
+ *
+ * @param {string} sourceId - The source ID (e.g., "ws.client_123" or "nmea0183-1")
+ * @param {Array} devices - Array of device objects (can be null/undefined)
+ * @returns {string} The display name
+ */
+export function getSourceDisplayName(sourceId, devices) {
+  if (!sourceId) {
+    return sourceId
+  }
+
+  if (sourceId.startsWith('ws.')) {
+    return getWsDeviceDisplayName(sourceId, devices)
+  }
+
+  return sourceId
+}
+
+/**
+ * Checks if a source/provider ID is a WebSocket device
+ *
+ * @param {string} id - The source or provider ID
+ * @returns {boolean} True if it's a WebSocket device ID
+ */
+export function isWsDevice(id) {
+  return id && typeof id === 'string' && id.startsWith('ws.')
+}

--- a/packages/server-admin-ui/src/views/Dashboard/Dashboard.js
+++ b/packages/server-admin-ui/src/views/Dashboard/Dashboard.js
@@ -10,6 +10,7 @@ import {
   Table
 } from 'reactstrap'
 import '../../fa-pulse.css'
+import { getWsDeviceDisplayName } from '../../utils/wsDeviceUtils'
 
 const Dashboard = (props) => {
   const {
@@ -17,13 +18,15 @@ const Dashboard = (props) => {
     numberOfAvailablePaths,
     wsClients,
     providerStatistics,
-    uptime
+    uptime,
+    devices
   } = props.serverStatistics || {
     deltaRate: 0,
     numberOfAvailablePaths: 0,
     wsClients: 0,
     providerStatistics: {},
-    uptime: ''
+    uptime: '',
+    devices: []
   }
   const providerStatus = props.providerStatus || []
   const errorCount = providerStatus.filter((s) => s.type === 'error').length
@@ -66,6 +69,7 @@ const Dashboard = (props) => {
   }
 
   const renderActivity = (providerId, providerStats, linkType) => {
+    const displayName = getWsDeviceDisplayName(providerId, devices)
     return (
       <li key={providerId} onClick={() => props.history.push(`/dashboard`)}>
         <i
@@ -84,7 +88,7 @@ const Dashboard = (props) => {
         <span className="title">
           {linkType === 'plugin'
             ? pluginNameLink(providerId)
-            : providerIdLink(providerId)}
+            : providerIdLink(providerId, displayName)}
         </span>
         {providerStats.writeRate > 0 && (
           <span className="value">
@@ -122,6 +126,7 @@ const Dashboard = (props) => {
   }
 
   const renderStatus = (status, statusClass, lastError) => {
+    const displayName = getWsDeviceDisplayName(status.id, devices)
     return (
       <tr
         key={status.id}
@@ -136,7 +141,7 @@ const Dashboard = (props) => {
         <td>
           {status.statusType === 'plugin'
             ? pluginNameLink(status.id)
-            : providerIdLink(status.id)}
+            : providerIdLink(status.id, displayName)}
         </td>
         <td>
           <p className="text-danger">{lastError}</p>
@@ -144,7 +149,7 @@ const Dashboard = (props) => {
         <td>
           <p className={statusClass}>
             {(status.message || '').substring(0, 80)}
-            {status.message.length > 80 ? '...' : ''}
+            {(status.message || '').length > 80 ? '...' : ''}
           </p>
         </td>
       </tr>
@@ -285,11 +290,11 @@ function pluginNameLink(id) {
   return <a href={'#/serverConfiguration/plugins/' + id}>{id}</a>
 }
 
-function providerIdLink(id) {
+function providerIdLink(id, name) {
   if (id === 'defaults') {
     return <a href={'#/serverConfiguration/settings'}>{id}</a>
   } else if (id.startsWith('ws.')) {
-    return <a href={'#/security/devices'}>{id}</a>
+    return <a href={'#/security/devices'}>{name}</a>
   } else {
     return <a href={'#/serverConfiguration/connections/' + id}>{id}</a>
   }

--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
@@ -17,6 +17,7 @@ import moment from 'moment'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import Meta from './Meta'
 import { getValueRenderer, DefaultValueRenderer } from './ValueRenderers'
+import { getSourceDisplayName } from '../../utils/wsDeviceUtils'
 
 const TIMESTAMP_FORMAT = 'MM/DD HH:mm:ss'
 const TIME_ONLY_FORMAT = 'HH:mm:ss'
@@ -690,7 +691,11 @@ class DataBrowser extends Component {
                                   }}
                                 />
                                 <CopyToClipboardWithFade text={data.$source}>
-                                  {data.$source} <i className="far fa-copy"></i>
+                                  {getSourceDisplayName(
+                                    data.$source,
+                                    this.props.serverStatistics?.devices
+                                  )}{' '}
+                                  <i className="far fa-copy"></i>
                                 </CopyToClipboardWithFade>{' '}
                                 {data.pgn || ''}
                                 {data.sentence || ''}
@@ -850,4 +855,7 @@ class CopyToClipboardWithFade extends Component {
   }
 }
 
-export default connect(({ webSocket }) => ({ webSocket }))(DataBrowser)
+export default connect(({ webSocket, serverStatistics }) => ({
+  webSocket,
+  serverStatistics
+}))(DataBrowser)

--- a/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.js
@@ -15,6 +15,7 @@ import {
 import Creatable from 'react-select/creatable'
 import remove from 'lodash.remove'
 import uniq from 'lodash.uniq'
+import { getSourceDisplayName } from '../../utils/wsDeviceUtils'
 
 export const SOURCEPRIOS_PRIO_CHANGED = 'SOURCEPRIOS_PPRIO_CHANGED'
 export const SOURCEPRIOS_PRIO_DELETED = 'SOURCEPRIOS_PRIO_DELETED'
@@ -189,10 +190,14 @@ class PrefsEditor extends Component {
             <tbody>
               {[...this.props.priorities, { sourceRef: '', timeout: '' }].map(
                 ({ sourceRef, timeout }, index) => {
-                  const options = this.state.sourceRefs.map((sourceRef) => ({
-                    label: sourceRef,
-                    value: sourceRef
+                  const options = this.state.sourceRefs.map((ref) => ({
+                    label: getSourceDisplayName(ref, this.props.devices),
+                    value: ref
                   }))
+                  const selectedLabel = getSourceDisplayName(
+                    sourceRef,
+                    this.props.devices
+                  )
                   return (
                     <tr key={index}>
                       <td>{index + 1}.</td>
@@ -200,7 +205,7 @@ class PrefsEditor extends Component {
                         <Creatable
                           menuPortalTarget={document.body}
                           options={options}
-                          value={{ value: sourceRef, label: sourceRef }}
+                          value={{ value: sourceRef, label: selectedLabel }}
                           onChange={(e) => {
                             this.props.dispatch({
                               type: SOURCEPRIOS_PRIO_CHANGED,
@@ -421,6 +426,7 @@ class SourcePriorities extends Component {
                         dispatch={this.props.dispatch}
                         isSaving={this.props.saveState.isSaving}
                         pathIndex={index}
+                        devices={this.props.devices}
                       />
                     </td>
                     <td style={{ border: 'none' }}>
@@ -478,9 +484,10 @@ class SourcePriorities extends Component {
   }
 }
 
-const mapStateToProps = ({ sourcePrioritiesData }) => ({
+const mapStateToProps = ({ sourcePrioritiesData, serverStatistics }) => ({
   sourcePriorities: sourcePrioritiesData.sourcePriorities,
-  saveState: sourcePrioritiesData.saveState
+  saveState: sourcePrioritiesData.saveState,
+  devices: serverStatistics?.devices || []
 })
 
 export default connect(mapStateToProps)(SourcePriorities)


### PR DESCRIPTION
* feat: ws devices use description as a name instead of id

* fix: ensure devices are retrieved safely from security strategy

* fix: formatting

* feat: extend WS device friendly names to all UI locations

- Create shared wsDeviceUtils.js utility for WS device name resolution
- Fix Dashboard status table to show device descriptions instead of raw IDs
- Extend DataBrowser to show friendly names for WS source references
- Extend SourcePriorities to show friendly names in source dropdown

This builds on the wsDevicesWithNamesAll branch work, adding consistent device name display across Dashboard, DataBrowser, and SourcePriorities.

* fix: correct WS device ID to clientId conversion and null guard

- Fix extractClientId to convert underscores back to dots (WS source is created as 'ws.' + identifier.replace(/\./g, '_') so we need to reverse: remove 'ws.' and convert '_' to '.')
- Add null guard for status.message.length check in Dashboard

* security: filter sensitive device data from SERVERSTATISTICS broadcast

The devices array was being broadcast to all connected clients including readonly/non-admin users. This leaked sensitive information like device permissions that should only be visible to admins.

Now only clientId and description are included in the broadcast, which are needed for display purposes. Full device info including permissions remains protected behind the admin-only /security/devices API.

* fix: handle composite $source format in WS device name lookup

Delta $source IDs can be composite like "ws.device_id.nmea0183.GGA" where the device part is followed by additional source path info.

Changed the lookup logic to:
- Convert device clientId to WS format (dots -> underscores)
- Match if the source starts with the device's WS-formatted ID
- Require exact match or followed by a dot (to avoid partial matches)

This fixes friendly name display in DataBrowser and SourcePriorities where $source from deltas includes additional source path components.