### PR TITLE
Fix source priority filtering at boot time

### DIFF
--- a/fix-source-priority-filtering-at-boot.patch
+++ b/fix-source-priority-filtering-at-boot.patch
@@ -1,7 +1,7 @@
 From e620b33c65eaa2cdd7341c0723f60d6eaeabfbf0 Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Fri, 26 Dec 2025 09:42:24 +0000
-Subject: [PATCH 1/6] Fix source priority filtering at boot time
+Subject: [PATCH 1/8] Fix source priority filtering at boot time
 
 The source priority filter was not correctly filtering sources during boot time.
 The issue was that when no previous value existed for a path, the filtering logic
@@ -157,7 +157,7 @@ index 8f0d620..8ab0610 100644
 From 6d935d9a5eb7e4f061db9ade32d9d34727404814 Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Fri, 26 Dec 2025 09:49:00 +0000
-Subject: [PATCH 2/6] Respect source priority timeouts at boot time
+Subject: [PATCH 2/8] Respect source priority timeouts at boot time
 
 Updated the boot-time filtering logic to respect cumulative timeouts for
 lower-priority sources, preventing all sources from being accepted immediately.
@@ -462,7 +462,7 @@ index 8ab0610..49a2bb1 100644
 From bfffcd630a2381feb3697e6076e18152f236fb57 Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Fri, 26 Dec 2025 09:52:12 +0000
-Subject: [PATCH 3/6] Add patch file for source priority filtering fix
+Subject: [PATCH 3/8] Add patch file for source priority filtering fix
 
 ---
  fix-source-priority-filtering-at-boot.patch | 460 ++++++++++++++++++++
@@ -942,7 +942,7 @@ index 0000000..41bbd13
 From 4da822bff3fa8031fe0761ccc90ac61e0803e65e Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Fri, 26 Dec 2025 09:56:00 +0000
-Subject: [PATCH 4/6] Remove trailing whitespaces from patch file
+Subject: [PATCH 4/8] Remove trailing whitespaces from patch file
 
 ---
  fix-source-priority-filtering-at-boot.patch | 26 ++++++++++-----------
@@ -1063,7 +1063,7 @@ index 41bbd13..af506f9 100644
 From 77d34343fd0a211e01b9a570b7457d1bd9b81cdd Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Fri, 26 Dec 2025 11:14:26 +0000
-Subject: [PATCH 5/6] Clarify filterStartTime comment in source priority
+Subject: [PATCH 5/8] Clarify filterStartTime comment in source priority
  filtering
 
 ---
@@ -1091,7 +1091,7 @@ index 1d2db09..ad663ea 100644
 From 77068a0bcfbca88fa8f7624852a03c10d2814b25 Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Fri, 26 Dec 2025 11:26:03 +0000
-Subject: [PATCH 6/6] Add comprehensive boot-time source priority filtering
+Subject: [PATCH 6/8] Add comprehensive boot-time source priority filtering
  tests
 
 Added two critical test cases to verify source priority filtering behavior:
@@ -1266,6 +1266,963 @@ index 49a2bb1..dd019f3 100644
    it('works', () => {
      const sourcePreferences: SourcePrioritiesData = {
        'environment.wind.speedApparent': [
+--
+2.43.0
+
+
+From c530e82bd15f8e06415219a11434ffd88c9acde2 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 26 Dec 2025 11:26:52 +0000
+Subject: [PATCH 7/8] Update patch file with comprehensive test cases
+
+---
+ fix-source-priority-filtering-at-boot.patch | 815 +++++++++++++++++++-
+ 1 file changed, 813 insertions(+), 2 deletions(-)
+
+diff --git a/fix-source-priority-filtering-at-boot.patch b/fix-source-priority-filtering-at-boot.patch
+index af506f9..d4fed93 100644
+--- a/fix-source-priority-filtering-at-boot.patch
++++ b/fix-source-priority-filtering-at-boot.patch
+@@ -1,7 +1,7 @@
+ From e620b33c65eaa2cdd7341c0723f60d6eaeabfbf0 Mon Sep 17 00:00:00 2001
+ From: Claude <noreply@anthropic.com>
+ Date: Fri, 26 Dec 2025 09:42:24 +0000
+-Subject: [PATCH 1/2] Fix source priority filtering at boot time
++Subject: [PATCH 1/6] Fix source priority filtering at boot time
+
+ The source priority filter was not correctly filtering sources during boot time.
+ The issue was that when no previous value existed for a path, the filtering logic
+@@ -157,7 +157,7 @@ index 8f0d620..8ab0610 100644
+ From 6d935d9a5eb7e4f061db9ade32d9d34727404814 Mon Sep 17 00:00:00 2001
+ From: Claude <noreply@anthropic.com>
+ Date: Fri, 26 Dec 2025 09:49:00 +0000
+-Subject: [PATCH 2/2] Respect source priority timeouts at boot time
++Subject: [PATCH 2/6] Respect source priority timeouts at boot time
+
+ Updated the boot-time filtering logic to respect cumulative timeouts for
+ lower-priority sources, preventing all sources from being accepted immediately.
+@@ -458,3 +458,814 @@ index 8ab0610..49a2bb1 100644
+ --
+ 2.43.0
+
++
++From bfffcd630a2381feb3697e6076e18152f236fb57 Mon Sep 17 00:00:00 2001
++From: Claude <noreply@anthropic.com>
++Date: Fri, 26 Dec 2025 09:52:12 +0000
++Subject: [PATCH 3/6] Add patch file for source priority filtering fix
++
++---
++ fix-source-priority-filtering-at-boot.patch | 460 ++++++++++++++++++++
++ 1 file changed, 460 insertions(+)
++ create mode 100644 fix-source-priority-filtering-at-boot.patch
++
++diff --git a/fix-source-priority-filtering-at-boot.patch b/fix-source-priority-filtering-at-boot.patch
++new file mode 100644
++index 0000000..41bbd13
++--- /dev/null
+++++ b/fix-source-priority-filtering-at-boot.patch
++@@ -0,0 +1,460 @@
+++From e620b33c65eaa2cdd7341c0723f60d6eaeabfbf0 Mon Sep 17 00:00:00 2001
+++From: Claude <noreply@anthropic.com>
+++Date: Fri, 26 Dec 2025 09:42:24 +0000
+++Subject: [PATCH 1/2] Fix source priority filtering at boot time
+++
+++The source priority filter was not correctly filtering sources during boot time.
+++The issue was that when no previous value existed for a path, the filtering logic
+++would fall back to HIGHESTPRECEDENCE for the empty latest source, causing the
+++timeout check to always pass (since latest.timestamp was 0, representing epoch time).
+++
+++This meant that ALL sources (both in and not in the priority list) would eventually
+++be accepted at boot time after their timeout expired, defeating the purpose of the
+++priority filter.
+++
+++Changes:
+++- Modified isPreferredValue() in src/deltaPriority.ts to handle the "no previous value" case
+++- When latest.sourceRef is empty (no value received yet):
+++  - Sources in the priority list are accepted immediately as the first value
+++  - Sources NOT in the priority list are rejected (they can only be used for failover)
+++- Added comprehensive test case to verify boot-time filtering behavior
+++
+++This ensures that source priority filtering works correctly from the moment the
+++server starts, not just after the first value is received.
+++---
+++ src/deltaPriority.ts  | 20 +++++++++++
+++ test/deltaPriority.ts | 82 +++++++++++++++++++++++++++++++++++++++++++
+++ 2 files changed, 102 insertions(+)
+++
+++diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
+++index b66b738..2ef8b4d 100644
+++--- a/src/deltaPriority.ts
++++++ b/src/deltaPriority.ts
+++@@ -123,6 +123,26 @@ export const getToPreferredDelta = (
+++       return true
+++     }
+++
++++    // Special case: no value received yet for this path
++++    // Accept any source from the priority list immediately
++++    // Reject sources not in the priority list (they can only be used for failover)
++++    // This fixes boot-time filtering where all sources were incorrectly allowed through
++++    if (latest.sourceRef === '') {
++++      const incomingPrecedence = pathPrecedences.get(sourceRef)
++++      if (incomingPrecedence) {
++++        // Source is in priority list - accept it as the first value
++++        if (debug.enabled) {
++++          debug(`${path}:${sourceRef}:true:first-value`)
++++        }
++++        return true
++++      }
++++      // Source not in priority list - reject at boot (no source to fail over from)
++++      if (debug.enabled) {
++++        debug(`${path}:${sourceRef}:false:unknown-source-at-boot`)
++++      }
++++      return false
++++    }
++++
+++     const latestPrecedence =
+++       pathPrecedences.get(latest.sourceRef) || HIGHESTPRECEDENCE
+++     const incomingPrecedence =
+++diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
+++index 8f0d620..8ab0610 100644
+++--- a/test/deltaPriority.ts
++++++ b/test/deltaPriority.ts
+++@@ -29,6 +29,88 @@ describe('toPreferredDelta logic', () => {
+++     assert(delta.updates[0].values === undefined)
+++   })
+++
++++  it('filters non-priority sources at boot time', () => {
++++    const sourcePreferences: SourcePrioritiesData = {
++++      'navigation.position': [
++++        {
++++          sourceRef: 'gps.main' as SourceRef,
++++          timeout: 5000
++++        },
++++        {
++++          sourceRef: 'gps.backup' as SourceRef,
++++          timeout: 5000
++++        }
++++      ]
++++    }
++++    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 10000)
++++
++++    // At boot time, non-priority source 'gps.unknown' should be rejected immediately
++++    const unknownSourceDelta = toPreferredDelta(
++++      {
++++        context: 'self',
++++        updates: [
++++          {
++++            $source: 'gps.unknown' as SourceRef,
++++            values: [
++++              {
++++                path: 'navigation.position',
++++                value: { latitude: 60.1, longitude: 24.9 }
++++              }
++++            ]
++++          }
++++        ]
++++      },
++++      new Date(),
++++      'self'
++++    )
++++    // Should filter out the value from unknown source at boot
++++    assert.strictEqual(unknownSourceDelta.updates[0].values.length, 0)
++++
++++    // Priority source 'gps.backup' should be accepted at boot (even though it's not first priority)
++++    const backupSourceDelta = toPreferredDelta(
++++      {
++++        context: 'self',
++++        updates: [
++++          {
++++            $source: 'gps.backup' as SourceRef,
++++            values: [
++++              {
++++                path: 'navigation.position',
++++                value: { latitude: 60.2, longitude: 24.8 }
++++              }
++++            ]
++++          }
++++        ]
++++      },
++++      new Date(),
++++      'self'
++++    )
++++    // Should accept the value from priority source
++++    assert.strictEqual(backupSourceDelta.updates[0].values.length, 1)
++++
++++    // Higher priority source 'gps.main' should replace backup
++++    const mainSourceDelta = toPreferredDelta(
++++      {
++++        context: 'self',
++++        updates: [
++++          {
++++            $source: 'gps.main' as SourceRef,
++++            values: [
++++              {
++++                path: 'navigation.position',
++++                value: { latitude: 60.3, longitude: 24.7 }
++++              }
++++            ]
++++          }
++++        ]
++++      },
++++      new Date(),
++++      'self'
++++    )
++++    // Should accept the value from higher priority source
++++    assert.strictEqual(mainSourceDelta.updates[0].values.length, 1)
++++  })
++++
+++   it('works', () => {
+++     const sourcePreferences: SourcePrioritiesData = {
+++       'environment.wind.speedApparent': [
+++--
+++2.43.0
+++
+++
+++From 6d935d9a5eb7e4f061db9ade32d9d34727404814 Mon Sep 17 00:00:00 2001
+++From: Claude <noreply@anthropic.com>
+++Date: Fri, 26 Dec 2025 09:49:00 +0000
+++Subject: [PATCH 2/2] Respect source priority timeouts at boot time
+++
+++Updated the boot-time filtering logic to respect cumulative timeouts for
+++lower-priority sources, preventing all sources from being accepted immediately.
+++
+++Previous behavior:
+++- All sources in the priority list were accepted immediately at boot
+++- This defeated the purpose of having priority ordering
+++
+++New behavior:
+++- Highest priority source (precedence 0): accepted immediately
+++- Lower priority sources: only accepted after cumulative timeout expires
+++  - Priority 1: accepted after timeout[0] milliseconds
+++  - Priority 2: accepted after timeout[0] + timeout[1] milliseconds
+++  - And so on...
+++- Unknown sources: accepted after unknownSourceTimeout milliseconds
+++
+++Example with priority list:
+++  1. gps.main (timeout: 5000ms)
+++  2. gps.backup (timeout: 3000ms)
+++  3. gps.tertiary (timeout: 2000ms)
+++
+++At boot:
+++- gps.main: accepted immediately
+++- gps.backup: accepted only after 5000ms (waiting for gps.main)
+++- gps.tertiary: accepted only after 8000ms (5000ms + 3000ms)
+++- unknown sources: accepted after 10000ms (unknownSourceTimeout)
+++
+++Changes:
+++- Track filter start time (filterStartTime) in src/deltaPriority.ts
+++- Calculate cumulative timeout for each source based on higher priority timeouts
+++- Updated comprehensive test case to verify timeout behavior
+++---
+++ src/deltaPriority.ts  |  41 ++++++++++---
+++ test/deltaPriority.ts | 137 ++++++++++++++++++++++++++++++++++++------
+++ 2 files changed, 148 insertions(+), 30 deletions(-)
+++
+++diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
+++index 2ef8b4d..1d2db09 100644
+++--- a/src/deltaPriority.ts
++++++ b/src/deltaPriority.ts
+++@@ -67,6 +67,9 @@ export const getToPreferredDelta = (
+++   }
+++   const precedences = toPrecedences(sourcePrioritiesData)
+++
++++  // Track when filtering started (boot time reference)
++++  const filterStartTime = Date.now()
++++
+++   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
+++
+++   const setLatest = (
+++@@ -123,24 +126,42 @@ export const getToPreferredDelta = (
+++       return true
+++     }
+++
+++-    // Special case: no value received yet for this path
+++-    // Accept any source from the priority list immediately
+++-    // Reject sources not in the priority list (they can only be used for failover)
+++-    // This fixes boot-time filtering where all sources were incorrectly allowed through
++++    // Special case: no value received yet for this path (boot time)
++++    // Respect priority list and timeouts to avoid accepting all sources immediately
+++     if (latest.sourceRef === '') {
+++       const incomingPrecedence = pathPrecedences.get(sourceRef)
+++       if (incomingPrecedence) {
+++-        // Source is in priority list - accept it as the first value
++++        // Source is in priority list - check if enough time has elapsed
++++        // based on cumulative timeouts of higher priority sources
++++
++++        // Calculate cumulative timeout: sum of timeouts for all higher precedence sources
++++        let cumulativeTimeout = 0
++++        for (const [, precedenceData] of pathPrecedences) {
++++          if (precedenceData.precedence < incomingPrecedence.precedence) {
++++            cumulativeTimeout += precedenceData.timeout
++++          }
++++        }
++++
++++        const timeSinceBoot = millis - filterStartTime
++++        const isPreferred = timeSinceBoot >= cumulativeTimeout
++++
+++         if (debug.enabled) {
+++-          debug(`${path}:${sourceRef}:true:first-value`)
++++          debug(
++++            `${path}:${sourceRef}:${isPreferred}:boot-time:precedence=${incomingPrecedence.precedence}:cumulative-timeout=${cumulativeTimeout}:time-since-boot=${timeSinceBoot}`
++++          )
+++         }
+++-        return true
++++        return isPreferred
+++       }
+++-      // Source not in priority list - reject at boot (no source to fail over from)
++++
++++      // Source not in priority list - apply unknown source timeout
++++      const timeSinceBoot = millis - filterStartTime
++++      const isPreferred = timeSinceBoot >= unknownSourceTimeout
+++       if (debug.enabled) {
+++-        debug(`${path}:${sourceRef}:false:unknown-source-at-boot`)
++++        debug(
++++          `${path}:${sourceRef}:${isPreferred}:boot-time:unknown-source:timeout=${unknownSourceTimeout}:time-since-boot=${timeSinceBoot}`
++++        )
+++       }
+++-      return false
++++      return isPreferred
+++     }
+++
+++     const latestPrecedence =
+++diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
+++index 8ab0610..49a2bb1 100644
+++--- a/test/deltaPriority.ts
++++++ b/test/deltaPriority.ts
+++@@ -29,28 +29,32 @@ describe('toPreferredDelta logic', () => {
+++     assert(delta.updates[0].values === undefined)
+++   })
+++
+++-  it('filters non-priority sources at boot time', () => {
++++  it('respects timeouts at boot time', () => {
+++     const sourcePreferences: SourcePrioritiesData = {
+++       'navigation.position': [
+++         {
+++           sourceRef: 'gps.main' as SourceRef,
+++-          timeout: 5000
++++          timeout: 100 // Wait 100ms before falling back
+++         },
+++         {
+++           sourceRef: 'gps.backup' as SourceRef,
+++-          timeout: 5000
++++          timeout: 100 // Wait another 100ms before falling back
++++        },
++++        {
++++          sourceRef: 'gps.tertiary' as SourceRef,
++++          timeout: 100
+++         }
+++       ]
+++     }
+++-    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 10000)
++++    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 400)
+++
+++-    // At boot time, non-priority source 'gps.unknown' should be rejected immediately
+++-    const unknownSourceDelta = toPreferredDelta(
++++    // Test 1: Highest priority source should be accepted immediately
++++    const mainSourceDelta = toPreferredDelta(
+++       {
+++         context: 'self',
+++         updates: [
+++           {
+++-            $source: 'gps.unknown' as SourceRef,
++++            $source: 'gps.main' as SourceRef,
+++             values: [
+++               {
+++                 path: 'navigation.position',
+++@@ -63,11 +67,14 @@ describe('toPreferredDelta logic', () => {
+++       new Date(),
+++       'self'
+++     )
+++-    // Should filter out the value from unknown source at boot
+++-    assert.strictEqual(unknownSourceDelta.updates[0].values.length, 0)
++++    // Highest priority should be accepted immediately
++++    assert.strictEqual(mainSourceDelta.updates[0].values.length, 1)
++++
++++    // Test 2: Create new filter to test timeout behavior from boot
++++    const toPreferredDelta2 = getToPreferredDelta(sourcePreferences, 400)
+++
+++-    // Priority source 'gps.backup' should be accepted at boot (even though it's not first priority)
+++-    const backupSourceDelta = toPreferredDelta(
++++    // Backup source should be rejected initially (before gps.main timeout expires)
++++    const backupSourceDeltaEarly = toPreferredDelta2(
+++       {
+++         context: 'self',
+++         updates: [
+++@@ -82,19 +89,19 @@ describe('toPreferredDelta logic', () => {
+++           }
+++         ]
+++       },
+++-      new Date(),
++++      new Date(Date.now() + 50), // 50ms after boot
+++       'self'
+++     )
+++-    // Should accept the value from priority source
+++-    assert.strictEqual(backupSourceDelta.updates[0].values.length, 1)
++++    // Should be rejected (cumulative timeout for backup = 100ms, but only 50ms elapsed)
++++    assert.strictEqual(backupSourceDeltaEarly.updates[0].values.length, 0)
+++
+++-    // Higher priority source 'gps.main' should replace backup
+++-    const mainSourceDelta = toPreferredDelta(
++++    // After timeout expires, backup source should be accepted
++++    const backupSourceDeltaLate = toPreferredDelta2(
+++       {
+++         context: 'self',
+++         updates: [
+++           {
+++-            $source: 'gps.main' as SourceRef,
++++            $source: 'gps.backup' as SourceRef,
+++             values: [
+++               {
+++                 path: 'navigation.position',
+++@@ -104,11 +111,101 @@ describe('toPreferredDelta logic', () => {
+++           }
+++         ]
+++       },
+++-      new Date(),
++++      new Date(Date.now() + 150), // 150ms after boot
+++       'self'
+++     )
+++-    // Should accept the value from higher priority source
+++-    assert.strictEqual(mainSourceDelta.updates[0].values.length, 1)
++++    // Should be accepted (cumulative timeout for backup = 100ms, 150ms elapsed)
++++    assert.strictEqual(backupSourceDeltaLate.updates[0].values.length, 1)
++++
++++    // Test 3: Tertiary source needs cumulative timeout of main + backup
++++    const toPreferredDelta3 = getToPreferredDelta(sourcePreferences, 400)
++++
++++    const tertiarySourceEarly = toPreferredDelta3(
++++      {
++++        context: 'self',
++++        updates: [
++++          {
++++            $source: 'gps.tertiary' as SourceRef,
++++            values: [
++++              {
++++                path: 'navigation.position',
++++                value: { latitude: 60.4, longitude: 24.6 }
++++              }
++++            ]
++++          }
++++        ]
++++      },
++++      new Date(Date.now() + 150), // 150ms after boot
++++      'self'
++++    )
++++    // Should be rejected (cumulative timeout = 100 + 100 = 200ms, but only 150ms elapsed)
++++    assert.strictEqual(tertiarySourceEarly.updates[0].values.length, 0)
++++
++++    const tertiarySourceLate = toPreferredDelta3(
++++      {
++++        context: 'self',
++++        updates: [
++++          {
++++            $source: 'gps.tertiary' as SourceRef,
++++            values: [
++++              {
++++                path: 'navigation.position',
++++                value: { latitude: 60.5, longitude: 24.5 }
++++              }
++++            ]
++++          }
++++        ]
++++      },
++++      new Date(Date.now() + 250), // 250ms after boot
++++      'self'
++++    )
++++    // Should be accepted (cumulative timeout = 200ms, 250ms elapsed)
++++    assert.strictEqual(tertiarySourceLate.updates[0].values.length, 1)
++++
++++    // Test 4: Unknown source should respect unknownSourceTimeout
++++    const toPreferredDelta4 = getToPreferredDelta(sourcePreferences, 400)
++++
++++    const unknownSourceEarly = toPreferredDelta4(
++++      {
++++        context: 'self',
++++        updates: [
++++          {
++++            $source: 'gps.unknown' as SourceRef,
++++            values: [
++++              {
++++                path: 'navigation.position',
++++                value: { latitude: 60.6, longitude: 24.4 }
++++              }
++++            ]
++++          }
++++        ]
++++      },
++++      new Date(Date.now() + 300), // 300ms after boot
++++      'self'
++++    )
++++    // Should be rejected (unknownSourceTimeout = 400ms, but only 300ms elapsed)
++++    assert.strictEqual(unknownSourceEarly.updates[0].values.length, 0)
++++
++++    const unknownSourceLate = toPreferredDelta4(
++++      {
++++        context: 'self',
++++        updates: [
++++          {
++++            $source: 'gps.unknown' as SourceRef,
++++            values: [
++++              {
++++                path: 'navigation.position',
++++                value: { latitude: 60.7, longitude: 24.3 }
++++              }
++++            ]
++++          }
++++        ]
++++      },
++++      new Date(Date.now() + 450), // 450ms after boot
++++      'self'
++++    )
++++    // Should be accepted (unknownSourceTimeout = 400ms, 450ms elapsed)
++++    assert.strictEqual(unknownSourceLate.updates[0].values.length, 1)
+++   })
+++
+++   it('works', () => {
+++--
+++2.43.0
+++
++--
++2.43.0
++
++
++From 4da822bff3fa8031fe0761ccc90ac61e0803e65e Mon Sep 17 00:00:00 2001
++From: Claude <noreply@anthropic.com>
++Date: Fri, 26 Dec 2025 09:56:00 +0000
++Subject: [PATCH 4/6] Remove trailing whitespaces from patch file
++
++---
++ fix-source-priority-filtering-at-boot.patch | 26 ++++++++++-----------
++ 1 file changed, 13 insertions(+), 13 deletions(-)
++
++diff --git a/fix-source-priority-filtering-at-boot.patch b/fix-source-priority-filtering-at-boot.patch
++index 41bbd13..af506f9 100644
++--- a/fix-source-priority-filtering-at-boot.patch
+++++ b/fix-source-priority-filtering-at-boot.patch
++@@ -33,7 +33,7 @@ index b66b738..2ef8b4d 100644
++ @@ -123,6 +123,26 @@ export const getToPreferredDelta = (
++        return true
++      }
++-
+++
++ +    // Special case: no value received yet for this path
++ +    // Accept any source from the priority list immediately
++ +    // Reject sources not in the priority list (they can only be used for failover)
++@@ -64,7 +64,7 @@ index 8f0d620..8ab0610 100644
++ @@ -29,6 +29,88 @@ describe('toPreferredDelta logic', () => {
++      assert(delta.updates[0].values === undefined)
++    })
++-
+++
++ +  it('filters non-priority sources at boot time', () => {
++ +    const sourcePreferences: SourcePrioritiesData = {
++ +      'navigation.position': [
++@@ -150,7 +150,7 @@ index 8f0d620..8ab0610 100644
++    it('works', () => {
++      const sourcePreferences: SourcePrioritiesData = {
++        'environment.wind.speedApparent': [
++---
+++--
++ 2.43.0
++
++
++@@ -201,17 +201,17 @@ index 2ef8b4d..1d2db09 100644
++ @@ -67,6 +67,9 @@ export const getToPreferredDelta = (
++    }
++    const precedences = toPrecedences(sourcePrioritiesData)
++-
+++
++ +  // Track when filtering started (boot time reference)
++ +  const filterStartTime = Date.now()
++ +
++    const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
++-
+++
++    const setLatest = (
++ @@ -123,24 +126,42 @@ export const getToPreferredDelta = (
++        return true
++      }
++-
+++
++ -    // Special case: no value received yet for this path
++ -    // Accept any source from the priority list immediately
++ -    // Reject sources not in the priority list (they can only be used for failover)
++@@ -259,7 +259,7 @@ index 2ef8b4d..1d2db09 100644
++ -      return false
++ +      return isPreferred
++      }
++-
+++
++      const latestPrecedence =
++ diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
++ index 8ab0610..49a2bb1 100644
++@@ -268,7 +268,7 @@ index 8ab0610..49a2bb1 100644
++ @@ -29,28 +29,32 @@ describe('toPreferredDelta logic', () => {
++      assert(delta.updates[0].values === undefined)
++    })
++-
+++
++ -  it('filters non-priority sources at boot time', () => {
++ +  it('respects timeouts at boot time', () => {
++      const sourcePreferences: SourcePrioritiesData = {
++@@ -291,7 +291,7 @@ index 8ab0610..49a2bb1 100644
++      }
++ -    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 10000)
++ +    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 400)
++-
+++
++ -    // At boot time, non-priority source 'gps.unknown' should be rejected immediately
++ -    const unknownSourceDelta = toPreferredDelta(
++ +    // Test 1: Highest priority source should be accepted immediately
++@@ -316,7 +316,7 @@ index 8ab0610..49a2bb1 100644
++ +
++ +    // Test 2: Create new filter to test timeout behavior from boot
++ +    const toPreferredDelta2 = getToPreferredDelta(sourcePreferences, 400)
++-
+++
++ -    // Priority source 'gps.backup' should be accepted at boot (even though it's not first priority)
++ -    const backupSourceDelta = toPreferredDelta(
++ +    // Backup source should be rejected initially (before gps.main timeout expires)
++@@ -336,7 +336,7 @@ index 8ab0610..49a2bb1 100644
++ -    assert.strictEqual(backupSourceDelta.updates[0].values.length, 1)
++ +    // Should be rejected (cumulative timeout for backup = 100ms, but only 50ms elapsed)
++ +    assert.strictEqual(backupSourceDeltaEarly.updates[0].values.length, 0)
++-
+++
++ -    // Higher priority source 'gps.main' should replace backup
++ -    const mainSourceDelta = toPreferredDelta(
++ +    // After timeout expires, backup source should be accepted
++@@ -453,8 +453,8 @@ index 8ab0610..49a2bb1 100644
++ +    // Should be accepted (unknownSourceTimeout = 400ms, 450ms elapsed)
++ +    assert.strictEqual(unknownSourceLate.updates[0].values.length, 1)
++    })
++-
+++
++    it('works', () => {
++---
+++--
++ 2.43.0
++
++--
++2.43.0
++
++
++From 77d34343fd0a211e01b9a570b7457d1bd9b81cdd Mon Sep 17 00:00:00 2001
++From: Claude <noreply@anthropic.com>
++Date: Fri, 26 Dec 2025 11:14:26 +0000
++Subject: [PATCH 5/6] Clarify filterStartTime comment in source priority
++ filtering
++
++---
++ src/deltaPriority.ts | 3 ++-
++ 1 file changed, 2 insertions(+), 1 deletion(-)
++
++diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
++index 1d2db09..ad663ea 100644
++--- a/src/deltaPriority.ts
+++++ b/src/deltaPriority.ts
++@@ -67,7 +67,8 @@ export const getToPreferredDelta = (
++   }
++   const precedences = toPrecedences(sourcePrioritiesData)
++
++-  // Track when filtering started (boot time reference)
+++  // Capture filter start time as boot time reference
+++  // This represents when filtering was activated, NOT when config was updated
++   const filterStartTime = Date.now()
++
++   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
++--
++2.43.0
++
++
++From 77068a0bcfbca88fa8f7624852a03c10d2814b25 Mon Sep 17 00:00:00 2001
++From: Claude <noreply@anthropic.com>
++Date: Fri, 26 Dec 2025 11:26:03 +0000
++Subject: [PATCH 6/6] Add comprehensive boot-time source priority filtering
++ tests
++
++Added two critical test cases to verify source priority filtering behavior:
++
++1. "filters 2nd priority source at boot, accepts after timeout"
++   - Verifies that lower priority sources are rejected at boot
++   - Confirms they are accepted after timeout expires if higher priority
++     sources never appear
++   - Tests the cumulative timeout mechanism
++
++2. "accepts 1st priority source when both send within timeout"
++   - Tests scenario where 2nd priority source sends first
++   - Verifies 1st priority source is accepted when it arrives within timeout
++   - Confirms 2nd priority source remains filtered after 1st priority becomes active
++
++These tests ensure the boot-time filtering logic correctly handles real-world
++scenarios where sources may arrive in any order.
++---
++ test/deltaPriority.ts | 142 ++++++++++++++++++++++++++++++++++++++++++
++ 1 file changed, 142 insertions(+)
++
++diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
++index 49a2bb1..dd019f3 100644
++--- a/test/deltaPriority.ts
+++++ b/test/deltaPriority.ts
++@@ -208,6 +208,148 @@ describe('toPreferredDelta logic', () => {
++     assert.strictEqual(unknownSourceLate.updates[0].values.length, 1)
++   })
++
+++  it('filters 2nd priority source at boot, accepts after timeout', () => {
+++    const sourcePreferences: SourcePrioritiesData = {
+++      'navigation.speedOverGround': [
+++        {
+++          sourceRef: 'gps.primary' as SourceRef,
+++          timeout: 200 // Wait 200ms before accepting backup
+++        },
+++        {
+++          sourceRef: 'gps.secondary' as SourceRef,
+++          timeout: 200
+++        }
+++      ]
+++    }
+++    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 500)
+++
+++    // Feed 2nd priority source first at boot - should be rejected
+++    const secondaryEarly = toPreferredDelta(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.secondary' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.speedOverGround',
+++                value: 5.2
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(Date.now() + 50), // 50ms after boot
+++      'self'
+++    )
+++    // Should be rejected (cumulative timeout = 200ms, only 50ms elapsed)
+++    assert.strictEqual(secondaryEarly.updates[0].values.length, 0)
+++
+++    // Wait for timeout to expire, feed 2nd source again - should be accepted
+++    const secondaryLate = toPreferredDelta(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.secondary' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.speedOverGround',
+++                value: 5.3
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(Date.now() + 250), // 250ms after boot (past 200ms timeout)
+++      'self'
+++    )
+++    // Should be accepted now (timeout expired, primary never showed up)
+++    assert.strictEqual(secondaryLate.updates[0].values.length, 1)
+++  })
+++
+++  it('accepts 1st priority source when both send within timeout', () => {
+++    const sourcePreferences: SourcePrioritiesData = {
+++      'navigation.courseOverGroundTrue': [
+++        {
+++          sourceRef: 'gps.main' as SourceRef,
+++          timeout: 300
+++        },
+++        {
+++          sourceRef: 'gps.backup' as SourceRef,
+++          timeout: 300
+++        }
+++      ]
+++    }
+++    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 500)
+++
+++    // Feed 2nd priority source first
+++    const backupFirst = toPreferredDelta(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.backup' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.courseOverGroundTrue',
+++                value: 180.5
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(Date.now() + 50), // 50ms after boot
+++      'self'
+++    )
+++    // Should be rejected (within timeout window, waiting for primary)
+++    assert.strictEqual(backupFirst.updates[0].values.length, 0)
+++
+++    // Feed 1st priority source shortly after (still within timeout)
+++    const mainSource = toPreferredDelta(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.main' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.courseOverGroundTrue',
+++                value: 181.2
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(Date.now() + 100), // 100ms after boot
+++      'self'
+++    )
+++    // Should be accepted (highest priority, no timeout needed)
+++    assert.strictEqual(mainSource.updates[0].values.length, 1)
+++
+++    // Now feed backup again - should be rejected because primary is active
+++    const backupAfterMain = toPreferredDelta(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.backup' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.courseOverGroundTrue',
+++                value: 180.8
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(Date.now() + 150), // 150ms after boot
+++      'self'
+++    )
+++    // Should be rejected (primary source is active and hasn't timed out)
+++    assert.strictEqual(backupAfterMain.updates[0].values.length, 0)
+++  })
+++
++   it('works', () => {
++     const sourcePreferences: SourcePrioritiesData = {
++       'environment.wind.speedApparent': [
++--
++2.43.0
++
+--
+2.43.0
+
+
+From a191225ec8398928c11c460c282bd98f92693243 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 26 Dec 2025 12:00:33 +0000
+Subject: [PATCH 8/8] Fix boot-time filtering with lazy filterStartTime
+ initialization
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+PROBLEM:
+filterStartTime was captured when the filter was created (in constructor),
+but data didn't flow until later (in start() method). This gap could be
+500-1000ms+, causing lower-priority sources to incorrectly pass timeout
+checks at boot.
+
+Example:
+- Constructor at T=0: filterStartTime = 0
+- start() at T=500ms: sendBaseDeltas sends historical data
+- Data processed at T=500ms with timeSinceBoot = 500ms
+- If timeout is 200ms, BOTH sources pass (500ms > 200ms) ✗
+
+SOLUTION:
+Lazy-initialize filterStartTime on first delta arrival, not at filter creation.
+Now boot time is measured from when data actually starts flowing.
+
+With lazy initialization:
+- Filter created, filterStartTime = null
+- First delta arrives at T=500ms: filterStartTime = 500ms
+- Second delta at T=550ms: timeSinceBoot = 50ms
+- Timeout check works correctly (50ms < 200ms) ✓
+
+Changes:
+- deltaPriority.ts: filterStartTime now initialized to null
+- deltaPriority.ts: Set filterStartTime on first delta in boot-time logic
+- test/deltaPriority.ts: Updated test timestamps to account for lazy init
+---
+ src/deltaPriority.ts  | 13 +++++++++----
+ test/deltaPriority.ts |  8 ++++----
+ 2 files changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
+index ad663ea..129ad06 100644
+--- a/src/deltaPriority.ts
++++ b/src/deltaPriority.ts
+@@ -67,12 +67,12 @@ export const getToPreferredDelta = (
+   }
+   const precedences = toPrecedences(sourcePrioritiesData)
+
+-  // Capture filter start time as boot time reference
+-  // This represents when filtering was activated, NOT when config was updated
+-  const filterStartTime = Date.now()
+-
+   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
+
++  // Lazy-initialize boot time on first delta to avoid timing issues
++  // where constructor runs before data flows
++  let filterStartTime: number | null = null
++
+   const setLatest = (
+     context: Context,
+     path: Path,
+@@ -130,6 +130,11 @@ export const getToPreferredDelta = (
+     // Special case: no value received yet for this path (boot time)
+     // Respect priority list and timeouts to avoid accepting all sources immediately
+     if (latest.sourceRef === '') {
++      // Initialize filter start time on first delta to avoid timing issues
++      if (filterStartTime === null) {
++        filterStartTime = millis
++      }
++
+       const incomingPrecedence = pathPrecedences.get(sourceRef)
+       if (incomingPrecedence) {
+         // Source is in priority list - check if enough time has elapsed
+diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
+index dd019f3..69c0a04 100644
+--- a/test/deltaPriority.ts
++++ b/test/deltaPriority.ts
+@@ -156,10 +156,10 @@ describe('toPreferredDelta logic', () => {
+           }
+         ]
+       },
+-      new Date(Date.now() + 250), // 250ms after boot
++      new Date(Date.now() + 350), // 350ms after first call, 200ms after first delta
+       'self'
+     )
+-    // Should be accepted (cumulative timeout = 200ms, 250ms elapsed)
++    // Should be accepted (cumulative timeout = 200ms, 200ms elapsed since first delta)
+     assert.strictEqual(tertiarySourceLate.updates[0].values.length, 1)
+
+     // Test 4: Unknown source should respect unknownSourceTimeout
+@@ -201,10 +201,10 @@ describe('toPreferredDelta logic', () => {
+           }
+         ]
+       },
+-      new Date(Date.now() + 450), // 450ms after boot
++      new Date(Date.now() + 700), // 700ms after first call, 400ms after first delta
+       'self'
+     )
+-    // Should be accepted (unknownSourceTimeout = 400ms, 450ms elapsed)
++    // Should be accepted (unknownSourceTimeout = 400ms, 400ms elapsed since first delta)
+     assert.strictEqual(unknownSourceLate.updates[0].values.length, 1)
+   })
+
 --
 2.43.0
 

--- a/fix-source-priority-filtering-at-boot.patch
+++ b/fix-source-priority-filtering-at-boot.patch
@@ -1,7 +1,7 @@
 From e620b33c65eaa2cdd7341c0723f60d6eaeabfbf0 Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Fri, 26 Dec 2025 09:42:24 +0000
-Subject: [PATCH 1/2] Fix source priority filtering at boot time
+Subject: [PATCH 1/6] Fix source priority filtering at boot time
 
 The source priority filter was not correctly filtering sources during boot time.
 The issue was that when no previous value existed for a path, the filtering logic
@@ -157,7 +157,7 @@ index 8f0d620..8ab0610 100644
 From 6d935d9a5eb7e4f061db9ade32d9d34727404814 Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Fri, 26 Dec 2025 09:49:00 +0000
-Subject: [PATCH 2/2] Respect source priority timeouts at boot time
+Subject: [PATCH 2/6] Respect source priority timeouts at boot time
 
 Updated the boot-time filtering logic to respect cumulative timeouts for
 lower-priority sources, preventing all sources from being accepted immediately.
@@ -455,6 +455,817 @@ index 8ab0610..49a2bb1 100644
    })
 
    it('works', () => {
+--
+2.43.0
+
+
+From bfffcd630a2381feb3697e6076e18152f236fb57 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 26 Dec 2025 09:52:12 +0000
+Subject: [PATCH 3/6] Add patch file for source priority filtering fix
+
+---
+ fix-source-priority-filtering-at-boot.patch | 460 ++++++++++++++++++++
+ 1 file changed, 460 insertions(+)
+ create mode 100644 fix-source-priority-filtering-at-boot.patch
+
+diff --git a/fix-source-priority-filtering-at-boot.patch b/fix-source-priority-filtering-at-boot.patch
+new file mode 100644
+index 0000000..41bbd13
+--- /dev/null
++++ b/fix-source-priority-filtering-at-boot.patch
+@@ -0,0 +1,460 @@
++From e620b33c65eaa2cdd7341c0723f60d6eaeabfbf0 Mon Sep 17 00:00:00 2001
++From: Claude <noreply@anthropic.com>
++Date: Fri, 26 Dec 2025 09:42:24 +0000
++Subject: [PATCH 1/2] Fix source priority filtering at boot time
++
++The source priority filter was not correctly filtering sources during boot time.
++The issue was that when no previous value existed for a path, the filtering logic
++would fall back to HIGHESTPRECEDENCE for the empty latest source, causing the
++timeout check to always pass (since latest.timestamp was 0, representing epoch time).
++
++This meant that ALL sources (both in and not in the priority list) would eventually
++be accepted at boot time after their timeout expired, defeating the purpose of the
++priority filter.
++
++Changes:
++- Modified isPreferredValue() in src/deltaPriority.ts to handle the "no previous value" case
++- When latest.sourceRef is empty (no value received yet):
++  - Sources in the priority list are accepted immediately as the first value
++  - Sources NOT in the priority list are rejected (they can only be used for failover)
++- Added comprehensive test case to verify boot-time filtering behavior
++
++This ensures that source priority filtering works correctly from the moment the
++server starts, not just after the first value is received.
++---
++ src/deltaPriority.ts  | 20 +++++++++++
++ test/deltaPriority.ts | 82 +++++++++++++++++++++++++++++++++++++++++++
++ 2 files changed, 102 insertions(+)
++
++diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
++index b66b738..2ef8b4d 100644
++--- a/src/deltaPriority.ts
+++++ b/src/deltaPriority.ts
++@@ -123,6 +123,26 @@ export const getToPreferredDelta = (
++       return true
++     }
++
+++    // Special case: no value received yet for this path
+++    // Accept any source from the priority list immediately
+++    // Reject sources not in the priority list (they can only be used for failover)
+++    // This fixes boot-time filtering where all sources were incorrectly allowed through
+++    if (latest.sourceRef === '') {
+++      const incomingPrecedence = pathPrecedences.get(sourceRef)
+++      if (incomingPrecedence) {
+++        // Source is in priority list - accept it as the first value
+++        if (debug.enabled) {
+++          debug(`${path}:${sourceRef}:true:first-value`)
+++        }
+++        return true
+++      }
+++      // Source not in priority list - reject at boot (no source to fail over from)
+++      if (debug.enabled) {
+++        debug(`${path}:${sourceRef}:false:unknown-source-at-boot`)
+++      }
+++      return false
+++    }
+++
++     const latestPrecedence =
++       pathPrecedences.get(latest.sourceRef) || HIGHESTPRECEDENCE
++     const incomingPrecedence =
++diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
++index 8f0d620..8ab0610 100644
++--- a/test/deltaPriority.ts
+++++ b/test/deltaPriority.ts
++@@ -29,6 +29,88 @@ describe('toPreferredDelta logic', () => {
++     assert(delta.updates[0].values === undefined)
++   })
++
+++  it('filters non-priority sources at boot time', () => {
+++    const sourcePreferences: SourcePrioritiesData = {
+++      'navigation.position': [
+++        {
+++          sourceRef: 'gps.main' as SourceRef,
+++          timeout: 5000
+++        },
+++        {
+++          sourceRef: 'gps.backup' as SourceRef,
+++          timeout: 5000
+++        }
+++      ]
+++    }
+++    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 10000)
+++
+++    // At boot time, non-priority source 'gps.unknown' should be rejected immediately
+++    const unknownSourceDelta = toPreferredDelta(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.unknown' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.position',
+++                value: { latitude: 60.1, longitude: 24.9 }
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(),
+++      'self'
+++    )
+++    // Should filter out the value from unknown source at boot
+++    assert.strictEqual(unknownSourceDelta.updates[0].values.length, 0)
+++
+++    // Priority source 'gps.backup' should be accepted at boot (even though it's not first priority)
+++    const backupSourceDelta = toPreferredDelta(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.backup' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.position',
+++                value: { latitude: 60.2, longitude: 24.8 }
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(),
+++      'self'
+++    )
+++    // Should accept the value from priority source
+++    assert.strictEqual(backupSourceDelta.updates[0].values.length, 1)
+++
+++    // Higher priority source 'gps.main' should replace backup
+++    const mainSourceDelta = toPreferredDelta(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.main' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.position',
+++                value: { latitude: 60.3, longitude: 24.7 }
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(),
+++      'self'
+++    )
+++    // Should accept the value from higher priority source
+++    assert.strictEqual(mainSourceDelta.updates[0].values.length, 1)
+++  })
+++
++   it('works', () => {
++     const sourcePreferences: SourcePrioritiesData = {
++       'environment.wind.speedApparent': [
++--
++2.43.0
++
++
++From 6d935d9a5eb7e4f061db9ade32d9d34727404814 Mon Sep 17 00:00:00 2001
++From: Claude <noreply@anthropic.com>
++Date: Fri, 26 Dec 2025 09:49:00 +0000
++Subject: [PATCH 2/2] Respect source priority timeouts at boot time
++
++Updated the boot-time filtering logic to respect cumulative timeouts for
++lower-priority sources, preventing all sources from being accepted immediately.
++
++Previous behavior:
++- All sources in the priority list were accepted immediately at boot
++- This defeated the purpose of having priority ordering
++
++New behavior:
++- Highest priority source (precedence 0): accepted immediately
++- Lower priority sources: only accepted after cumulative timeout expires
++  - Priority 1: accepted after timeout[0] milliseconds
++  - Priority 2: accepted after timeout[0] + timeout[1] milliseconds
++  - And so on...
++- Unknown sources: accepted after unknownSourceTimeout milliseconds
++
++Example with priority list:
++  1. gps.main (timeout: 5000ms)
++  2. gps.backup (timeout: 3000ms)
++  3. gps.tertiary (timeout: 2000ms)
++
++At boot:
++- gps.main: accepted immediately
++- gps.backup: accepted only after 5000ms (waiting for gps.main)
++- gps.tertiary: accepted only after 8000ms (5000ms + 3000ms)
++- unknown sources: accepted after 10000ms (unknownSourceTimeout)
++
++Changes:
++- Track filter start time (filterStartTime) in src/deltaPriority.ts
++- Calculate cumulative timeout for each source based on higher priority timeouts
++- Updated comprehensive test case to verify timeout behavior
++---
++ src/deltaPriority.ts  |  41 ++++++++++---
++ test/deltaPriority.ts | 137 ++++++++++++++++++++++++++++++++++++------
++ 2 files changed, 148 insertions(+), 30 deletions(-)
++
++diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
++index 2ef8b4d..1d2db09 100644
++--- a/src/deltaPriority.ts
+++++ b/src/deltaPriority.ts
++@@ -67,6 +67,9 @@ export const getToPreferredDelta = (
++   }
++   const precedences = toPrecedences(sourcePrioritiesData)
++
+++  // Track when filtering started (boot time reference)
+++  const filterStartTime = Date.now()
+++
++   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
++
++   const setLatest = (
++@@ -123,24 +126,42 @@ export const getToPreferredDelta = (
++       return true
++     }
++
++-    // Special case: no value received yet for this path
++-    // Accept any source from the priority list immediately
++-    // Reject sources not in the priority list (they can only be used for failover)
++-    // This fixes boot-time filtering where all sources were incorrectly allowed through
+++    // Special case: no value received yet for this path (boot time)
+++    // Respect priority list and timeouts to avoid accepting all sources immediately
++     if (latest.sourceRef === '') {
++       const incomingPrecedence = pathPrecedences.get(sourceRef)
++       if (incomingPrecedence) {
++-        // Source is in priority list - accept it as the first value
+++        // Source is in priority list - check if enough time has elapsed
+++        // based on cumulative timeouts of higher priority sources
+++
+++        // Calculate cumulative timeout: sum of timeouts for all higher precedence sources
+++        let cumulativeTimeout = 0
+++        for (const [, precedenceData] of pathPrecedences) {
+++          if (precedenceData.precedence < incomingPrecedence.precedence) {
+++            cumulativeTimeout += precedenceData.timeout
+++          }
+++        }
+++
+++        const timeSinceBoot = millis - filterStartTime
+++        const isPreferred = timeSinceBoot >= cumulativeTimeout
+++
++         if (debug.enabled) {
++-          debug(`${path}:${sourceRef}:true:first-value`)
+++          debug(
+++            `${path}:${sourceRef}:${isPreferred}:boot-time:precedence=${incomingPrecedence.precedence}:cumulative-timeout=${cumulativeTimeout}:time-since-boot=${timeSinceBoot}`
+++          )
++         }
++-        return true
+++        return isPreferred
++       }
++-      // Source not in priority list - reject at boot (no source to fail over from)
+++
+++      // Source not in priority list - apply unknown source timeout
+++      const timeSinceBoot = millis - filterStartTime
+++      const isPreferred = timeSinceBoot >= unknownSourceTimeout
++       if (debug.enabled) {
++-        debug(`${path}:${sourceRef}:false:unknown-source-at-boot`)
+++        debug(
+++          `${path}:${sourceRef}:${isPreferred}:boot-time:unknown-source:timeout=${unknownSourceTimeout}:time-since-boot=${timeSinceBoot}`
+++        )
++       }
++-      return false
+++      return isPreferred
++     }
++
++     const latestPrecedence =
++diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
++index 8ab0610..49a2bb1 100644
++--- a/test/deltaPriority.ts
+++++ b/test/deltaPriority.ts
++@@ -29,28 +29,32 @@ describe('toPreferredDelta logic', () => {
++     assert(delta.updates[0].values === undefined)
++   })
++
++-  it('filters non-priority sources at boot time', () => {
+++  it('respects timeouts at boot time', () => {
++     const sourcePreferences: SourcePrioritiesData = {
++       'navigation.position': [
++         {
++           sourceRef: 'gps.main' as SourceRef,
++-          timeout: 5000
+++          timeout: 100 // Wait 100ms before falling back
++         },
++         {
++           sourceRef: 'gps.backup' as SourceRef,
++-          timeout: 5000
+++          timeout: 100 // Wait another 100ms before falling back
+++        },
+++        {
+++          sourceRef: 'gps.tertiary' as SourceRef,
+++          timeout: 100
++         }
++       ]
++     }
++-    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 10000)
+++    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 400)
++
++-    // At boot time, non-priority source 'gps.unknown' should be rejected immediately
++-    const unknownSourceDelta = toPreferredDelta(
+++    // Test 1: Highest priority source should be accepted immediately
+++    const mainSourceDelta = toPreferredDelta(
++       {
++         context: 'self',
++         updates: [
++           {
++-            $source: 'gps.unknown' as SourceRef,
+++            $source: 'gps.main' as SourceRef,
++             values: [
++               {
++                 path: 'navigation.position',
++@@ -63,11 +67,14 @@ describe('toPreferredDelta logic', () => {
++       new Date(),
++       'self'
++     )
++-    // Should filter out the value from unknown source at boot
++-    assert.strictEqual(unknownSourceDelta.updates[0].values.length, 0)
+++    // Highest priority should be accepted immediately
+++    assert.strictEqual(mainSourceDelta.updates[0].values.length, 1)
+++
+++    // Test 2: Create new filter to test timeout behavior from boot
+++    const toPreferredDelta2 = getToPreferredDelta(sourcePreferences, 400)
++
++-    // Priority source 'gps.backup' should be accepted at boot (even though it's not first priority)
++-    const backupSourceDelta = toPreferredDelta(
+++    // Backup source should be rejected initially (before gps.main timeout expires)
+++    const backupSourceDeltaEarly = toPreferredDelta2(
++       {
++         context: 'self',
++         updates: [
++@@ -82,19 +89,19 @@ describe('toPreferredDelta logic', () => {
++           }
++         ]
++       },
++-      new Date(),
+++      new Date(Date.now() + 50), // 50ms after boot
++       'self'
++     )
++-    // Should accept the value from priority source
++-    assert.strictEqual(backupSourceDelta.updates[0].values.length, 1)
+++    // Should be rejected (cumulative timeout for backup = 100ms, but only 50ms elapsed)
+++    assert.strictEqual(backupSourceDeltaEarly.updates[0].values.length, 0)
++
++-    // Higher priority source 'gps.main' should replace backup
++-    const mainSourceDelta = toPreferredDelta(
+++    // After timeout expires, backup source should be accepted
+++    const backupSourceDeltaLate = toPreferredDelta2(
++       {
++         context: 'self',
++         updates: [
++           {
++-            $source: 'gps.main' as SourceRef,
+++            $source: 'gps.backup' as SourceRef,
++             values: [
++               {
++                 path: 'navigation.position',
++@@ -104,11 +111,101 @@ describe('toPreferredDelta logic', () => {
++           }
++         ]
++       },
++-      new Date(),
+++      new Date(Date.now() + 150), // 150ms after boot
++       'self'
++     )
++-    // Should accept the value from higher priority source
++-    assert.strictEqual(mainSourceDelta.updates[0].values.length, 1)
+++    // Should be accepted (cumulative timeout for backup = 100ms, 150ms elapsed)
+++    assert.strictEqual(backupSourceDeltaLate.updates[0].values.length, 1)
+++
+++    // Test 3: Tertiary source needs cumulative timeout of main + backup
+++    const toPreferredDelta3 = getToPreferredDelta(sourcePreferences, 400)
+++
+++    const tertiarySourceEarly = toPreferredDelta3(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.tertiary' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.position',
+++                value: { latitude: 60.4, longitude: 24.6 }
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(Date.now() + 150), // 150ms after boot
+++      'self'
+++    )
+++    // Should be rejected (cumulative timeout = 100 + 100 = 200ms, but only 150ms elapsed)
+++    assert.strictEqual(tertiarySourceEarly.updates[0].values.length, 0)
+++
+++    const tertiarySourceLate = toPreferredDelta3(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.tertiary' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.position',
+++                value: { latitude: 60.5, longitude: 24.5 }
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(Date.now() + 250), // 250ms after boot
+++      'self'
+++    )
+++    // Should be accepted (cumulative timeout = 200ms, 250ms elapsed)
+++    assert.strictEqual(tertiarySourceLate.updates[0].values.length, 1)
+++
+++    // Test 4: Unknown source should respect unknownSourceTimeout
+++    const toPreferredDelta4 = getToPreferredDelta(sourcePreferences, 400)
+++
+++    const unknownSourceEarly = toPreferredDelta4(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.unknown' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.position',
+++                value: { latitude: 60.6, longitude: 24.4 }
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(Date.now() + 300), // 300ms after boot
+++      'self'
+++    )
+++    // Should be rejected (unknownSourceTimeout = 400ms, but only 300ms elapsed)
+++    assert.strictEqual(unknownSourceEarly.updates[0].values.length, 0)
+++
+++    const unknownSourceLate = toPreferredDelta4(
+++      {
+++        context: 'self',
+++        updates: [
+++          {
+++            $source: 'gps.unknown' as SourceRef,
+++            values: [
+++              {
+++                path: 'navigation.position',
+++                value: { latitude: 60.7, longitude: 24.3 }
+++              }
+++            ]
+++          }
+++        ]
+++      },
+++      new Date(Date.now() + 450), // 450ms after boot
+++      'self'
+++    )
+++    // Should be accepted (unknownSourceTimeout = 400ms, 450ms elapsed)
+++    assert.strictEqual(unknownSourceLate.updates[0].values.length, 1)
++   })
++
++   it('works', () => {
++--
++2.43.0
++
+--
+2.43.0
+
+
+From 4da822bff3fa8031fe0761ccc90ac61e0803e65e Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 26 Dec 2025 09:56:00 +0000
+Subject: [PATCH 4/6] Remove trailing whitespaces from patch file
+
+---
+ fix-source-priority-filtering-at-boot.patch | 26 ++++++++++-----------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/fix-source-priority-filtering-at-boot.patch b/fix-source-priority-filtering-at-boot.patch
+index 41bbd13..af506f9 100644
+--- a/fix-source-priority-filtering-at-boot.patch
++++ b/fix-source-priority-filtering-at-boot.patch
+@@ -33,7 +33,7 @@ index b66b738..2ef8b4d 100644
+ @@ -123,6 +123,26 @@ export const getToPreferredDelta = (
+        return true
+      }
+-
++
+ +    // Special case: no value received yet for this path
+ +    // Accept any source from the priority list immediately
+ +    // Reject sources not in the priority list (they can only be used for failover)
+@@ -64,7 +64,7 @@ index 8f0d620..8ab0610 100644
+ @@ -29,6 +29,88 @@ describe('toPreferredDelta logic', () => {
+      assert(delta.updates[0].values === undefined)
+    })
+-
++
+ +  it('filters non-priority sources at boot time', () => {
+ +    const sourcePreferences: SourcePrioritiesData = {
+ +      'navigation.position': [
+@@ -150,7 +150,7 @@ index 8f0d620..8ab0610 100644
+    it('works', () => {
+      const sourcePreferences: SourcePrioritiesData = {
+        'environment.wind.speedApparent': [
+---
++--
+ 2.43.0
+
+
+@@ -201,17 +201,17 @@ index 2ef8b4d..1d2db09 100644
+ @@ -67,6 +67,9 @@ export const getToPreferredDelta = (
+    }
+    const precedences = toPrecedences(sourcePrioritiesData)
+-
++
+ +  // Track when filtering started (boot time reference)
+ +  const filterStartTime = Date.now()
+ +
+    const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
+-
++
+    const setLatest = (
+ @@ -123,24 +126,42 @@ export const getToPreferredDelta = (
+        return true
+      }
+-
++
+ -    // Special case: no value received yet for this path
+ -    // Accept any source from the priority list immediately
+ -    // Reject sources not in the priority list (they can only be used for failover)
+@@ -259,7 +259,7 @@ index 2ef8b4d..1d2db09 100644
+ -      return false
+ +      return isPreferred
+      }
+-
++
+      const latestPrecedence =
+ diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
+ index 8ab0610..49a2bb1 100644
+@@ -268,7 +268,7 @@ index 8ab0610..49a2bb1 100644
+ @@ -29,28 +29,32 @@ describe('toPreferredDelta logic', () => {
+      assert(delta.updates[0].values === undefined)
+    })
+-
++
+ -  it('filters non-priority sources at boot time', () => {
+ +  it('respects timeouts at boot time', () => {
+      const sourcePreferences: SourcePrioritiesData = {
+@@ -291,7 +291,7 @@ index 8ab0610..49a2bb1 100644
+      }
+ -    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 10000)
+ +    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 400)
+-
++
+ -    // At boot time, non-priority source 'gps.unknown' should be rejected immediately
+ -    const unknownSourceDelta = toPreferredDelta(
+ +    // Test 1: Highest priority source should be accepted immediately
+@@ -316,7 +316,7 @@ index 8ab0610..49a2bb1 100644
+ +
+ +    // Test 2: Create new filter to test timeout behavior from boot
+ +    const toPreferredDelta2 = getToPreferredDelta(sourcePreferences, 400)
+-
++
+ -    // Priority source 'gps.backup' should be accepted at boot (even though it's not first priority)
+ -    const backupSourceDelta = toPreferredDelta(
+ +    // Backup source should be rejected initially (before gps.main timeout expires)
+@@ -336,7 +336,7 @@ index 8ab0610..49a2bb1 100644
+ -    assert.strictEqual(backupSourceDelta.updates[0].values.length, 1)
+ +    // Should be rejected (cumulative timeout for backup = 100ms, but only 50ms elapsed)
+ +    assert.strictEqual(backupSourceDeltaEarly.updates[0].values.length, 0)
+-
++
+ -    // Higher priority source 'gps.main' should replace backup
+ -    const mainSourceDelta = toPreferredDelta(
+ +    // After timeout expires, backup source should be accepted
+@@ -453,8 +453,8 @@ index 8ab0610..49a2bb1 100644
+ +    // Should be accepted (unknownSourceTimeout = 400ms, 450ms elapsed)
+ +    assert.strictEqual(unknownSourceLate.updates[0].values.length, 1)
+    })
+-
++
+    it('works', () => {
+---
++--
+ 2.43.0
+
+--
+2.43.0
+
+
+From 77d34343fd0a211e01b9a570b7457d1bd9b81cdd Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 26 Dec 2025 11:14:26 +0000
+Subject: [PATCH 5/6] Clarify filterStartTime comment in source priority
+ filtering
+
+---
+ src/deltaPriority.ts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
+index 1d2db09..ad663ea 100644
+--- a/src/deltaPriority.ts
++++ b/src/deltaPriority.ts
+@@ -67,7 +67,8 @@ export const getToPreferredDelta = (
+   }
+   const precedences = toPrecedences(sourcePrioritiesData)
+
+-  // Track when filtering started (boot time reference)
++  // Capture filter start time as boot time reference
++  // This represents when filtering was activated, NOT when config was updated
+   const filterStartTime = Date.now()
+
+   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
+--
+2.43.0
+
+
+From 77068a0bcfbca88fa8f7624852a03c10d2814b25 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 26 Dec 2025 11:26:03 +0000
+Subject: [PATCH 6/6] Add comprehensive boot-time source priority filtering
+ tests
+
+Added two critical test cases to verify source priority filtering behavior:
+
+1. "filters 2nd priority source at boot, accepts after timeout"
+   - Verifies that lower priority sources are rejected at boot
+   - Confirms they are accepted after timeout expires if higher priority
+     sources never appear
+   - Tests the cumulative timeout mechanism
+
+2. "accepts 1st priority source when both send within timeout"
+   - Tests scenario where 2nd priority source sends first
+   - Verifies 1st priority source is accepted when it arrives within timeout
+   - Confirms 2nd priority source remains filtered after 1st priority becomes active
+
+These tests ensure the boot-time filtering logic correctly handles real-world
+scenarios where sources may arrive in any order.
+---
+ test/deltaPriority.ts | 142 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 142 insertions(+)
+
+diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
+index 49a2bb1..dd019f3 100644
+--- a/test/deltaPriority.ts
++++ b/test/deltaPriority.ts
+@@ -208,6 +208,148 @@ describe('toPreferredDelta logic', () => {
+     assert.strictEqual(unknownSourceLate.updates[0].values.length, 1)
+   })
+
++  it('filters 2nd priority source at boot, accepts after timeout', () => {
++    const sourcePreferences: SourcePrioritiesData = {
++      'navigation.speedOverGround': [
++        {
++          sourceRef: 'gps.primary' as SourceRef,
++          timeout: 200 // Wait 200ms before accepting backup
++        },
++        {
++          sourceRef: 'gps.secondary' as SourceRef,
++          timeout: 200
++        }
++      ]
++    }
++    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 500)
++
++    // Feed 2nd priority source first at boot - should be rejected
++    const secondaryEarly = toPreferredDelta(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.secondary' as SourceRef,
++            values: [
++              {
++                path: 'navigation.speedOverGround',
++                value: 5.2
++              }
++            ]
++          }
++        ]
++      },
++      new Date(Date.now() + 50), // 50ms after boot
++      'self'
++    )
++    // Should be rejected (cumulative timeout = 200ms, only 50ms elapsed)
++    assert.strictEqual(secondaryEarly.updates[0].values.length, 0)
++
++    // Wait for timeout to expire, feed 2nd source again - should be accepted
++    const secondaryLate = toPreferredDelta(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.secondary' as SourceRef,
++            values: [
++              {
++                path: 'navigation.speedOverGround',
++                value: 5.3
++              }
++            ]
++          }
++        ]
++      },
++      new Date(Date.now() + 250), // 250ms after boot (past 200ms timeout)
++      'self'
++    )
++    // Should be accepted now (timeout expired, primary never showed up)
++    assert.strictEqual(secondaryLate.updates[0].values.length, 1)
++  })
++
++  it('accepts 1st priority source when both send within timeout', () => {
++    const sourcePreferences: SourcePrioritiesData = {
++      'navigation.courseOverGroundTrue': [
++        {
++          sourceRef: 'gps.main' as SourceRef,
++          timeout: 300
++        },
++        {
++          sourceRef: 'gps.backup' as SourceRef,
++          timeout: 300
++        }
++      ]
++    }
++    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 500)
++
++    // Feed 2nd priority source first
++    const backupFirst = toPreferredDelta(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.backup' as SourceRef,
++            values: [
++              {
++                path: 'navigation.courseOverGroundTrue',
++                value: 180.5
++              }
++            ]
++          }
++        ]
++      },
++      new Date(Date.now() + 50), // 50ms after boot
++      'self'
++    )
++    // Should be rejected (within timeout window, waiting for primary)
++    assert.strictEqual(backupFirst.updates[0].values.length, 0)
++
++    // Feed 1st priority source shortly after (still within timeout)
++    const mainSource = toPreferredDelta(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.main' as SourceRef,
++            values: [
++              {
++                path: 'navigation.courseOverGroundTrue',
++                value: 181.2
++              }
++            ]
++          }
++        ]
++      },
++      new Date(Date.now() + 100), // 100ms after boot
++      'self'
++    )
++    // Should be accepted (highest priority, no timeout needed)
++    assert.strictEqual(mainSource.updates[0].values.length, 1)
++
++    // Now feed backup again - should be rejected because primary is active
++    const backupAfterMain = toPreferredDelta(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.backup' as SourceRef,
++            values: [
++              {
++                path: 'navigation.courseOverGroundTrue',
++                value: 180.8
++              }
++            ]
++          }
++        ]
++      },
++      new Date(Date.now() + 150), // 150ms after boot
++      'self'
++    )
++    // Should be rejected (primary source is active and hasn't timed out)
++    assert.strictEqual(backupAfterMain.updates[0].values.length, 0)
++  })
++
+   it('works', () => {
+     const sourcePreferences: SourcePrioritiesData = {
+       'environment.wind.speedApparent': [
 --
 2.43.0
 

--- a/fix-source-priority-filtering-at-boot.patch
+++ b/fix-source-priority-filtering-at-boot.patch
@@ -33,7 +33,7 @@ index b66b738..2ef8b4d 100644
 @@ -123,6 +123,26 @@ export const getToPreferredDelta = (
        return true
      }
- 
+
 +    // Special case: no value received yet for this path
 +    // Accept any source from the priority list immediately
 +    // Reject sources not in the priority list (they can only be used for failover)
@@ -64,7 +64,7 @@ index 8f0d620..8ab0610 100644
 @@ -29,6 +29,88 @@ describe('toPreferredDelta logic', () => {
      assert(delta.updates[0].values === undefined)
    })
- 
+
 +  it('filters non-priority sources at boot time', () => {
 +    const sourcePreferences: SourcePrioritiesData = {
 +      'navigation.position': [
@@ -150,7 +150,7 @@ index 8f0d620..8ab0610 100644
    it('works', () => {
      const sourcePreferences: SourcePrioritiesData = {
        'environment.wind.speedApparent': [
--- 
+--
 2.43.0
 
 
@@ -201,17 +201,17 @@ index 2ef8b4d..1d2db09 100644
 @@ -67,6 +67,9 @@ export const getToPreferredDelta = (
    }
    const precedences = toPrecedences(sourcePrioritiesData)
- 
+
 +  // Track when filtering started (boot time reference)
 +  const filterStartTime = Date.now()
 +
    const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
- 
+
    const setLatest = (
 @@ -123,24 +126,42 @@ export const getToPreferredDelta = (
        return true
      }
- 
+
 -    // Special case: no value received yet for this path
 -    // Accept any source from the priority list immediately
 -    // Reject sources not in the priority list (they can only be used for failover)
@@ -259,7 +259,7 @@ index 2ef8b4d..1d2db09 100644
 -      return false
 +      return isPreferred
      }
- 
+
      const latestPrecedence =
 diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
 index 8ab0610..49a2bb1 100644
@@ -268,7 +268,7 @@ index 8ab0610..49a2bb1 100644
 @@ -29,28 +29,32 @@ describe('toPreferredDelta logic', () => {
      assert(delta.updates[0].values === undefined)
    })
- 
+
 -  it('filters non-priority sources at boot time', () => {
 +  it('respects timeouts at boot time', () => {
      const sourcePreferences: SourcePrioritiesData = {
@@ -291,7 +291,7 @@ index 8ab0610..49a2bb1 100644
      }
 -    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 10000)
 +    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 400)
- 
+
 -    // At boot time, non-priority source 'gps.unknown' should be rejected immediately
 -    const unknownSourceDelta = toPreferredDelta(
 +    // Test 1: Highest priority source should be accepted immediately
@@ -316,7 +316,7 @@ index 8ab0610..49a2bb1 100644
 +
 +    // Test 2: Create new filter to test timeout behavior from boot
 +    const toPreferredDelta2 = getToPreferredDelta(sourcePreferences, 400)
- 
+
 -    // Priority source 'gps.backup' should be accepted at boot (even though it's not first priority)
 -    const backupSourceDelta = toPreferredDelta(
 +    // Backup source should be rejected initially (before gps.main timeout expires)
@@ -336,7 +336,7 @@ index 8ab0610..49a2bb1 100644
 -    assert.strictEqual(backupSourceDelta.updates[0].values.length, 1)
 +    // Should be rejected (cumulative timeout for backup = 100ms, but only 50ms elapsed)
 +    assert.strictEqual(backupSourceDeltaEarly.updates[0].values.length, 0)
- 
+
 -    // Higher priority source 'gps.main' should replace backup
 -    const mainSourceDelta = toPreferredDelta(
 +    // After timeout expires, backup source should be accepted
@@ -453,8 +453,8 @@ index 8ab0610..49a2bb1 100644
 +    // Should be accepted (unknownSourceTimeout = 400ms, 450ms elapsed)
 +    assert.strictEqual(unknownSourceLate.updates[0].values.length, 1)
    })
- 
+
    it('works', () => {
--- 
+--
 2.43.0
 

--- a/fix-source-priority-filtering-at-boot.patch
+++ b/fix-source-priority-filtering-at-boot.patch
@@ -1,0 +1,460 @@
+From e620b33c65eaa2cdd7341c0723f60d6eaeabfbf0 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 26 Dec 2025 09:42:24 +0000
+Subject: [PATCH 1/2] Fix source priority filtering at boot time
+
+The source priority filter was not correctly filtering sources during boot time.
+The issue was that when no previous value existed for a path, the filtering logic
+would fall back to HIGHESTPRECEDENCE for the empty latest source, causing the
+timeout check to always pass (since latest.timestamp was 0, representing epoch time).
+
+This meant that ALL sources (both in and not in the priority list) would eventually
+be accepted at boot time after their timeout expired, defeating the purpose of the
+priority filter.
+
+Changes:
+- Modified isPreferredValue() in src/deltaPriority.ts to handle the "no previous value" case
+- When latest.sourceRef is empty (no value received yet):
+  - Sources in the priority list are accepted immediately as the first value
+  - Sources NOT in the priority list are rejected (they can only be used for failover)
+- Added comprehensive test case to verify boot-time filtering behavior
+
+This ensures that source priority filtering works correctly from the moment the
+server starts, not just after the first value is received.
+---
+ src/deltaPriority.ts  | 20 +++++++++++
+ test/deltaPriority.ts | 82 +++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 102 insertions(+)
+
+diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
+index b66b738..2ef8b4d 100644
+--- a/src/deltaPriority.ts
++++ b/src/deltaPriority.ts
+@@ -123,6 +123,26 @@ export const getToPreferredDelta = (
+       return true
+     }
+ 
++    // Special case: no value received yet for this path
++    // Accept any source from the priority list immediately
++    // Reject sources not in the priority list (they can only be used for failover)
++    // This fixes boot-time filtering where all sources were incorrectly allowed through
++    if (latest.sourceRef === '') {
++      const incomingPrecedence = pathPrecedences.get(sourceRef)
++      if (incomingPrecedence) {
++        // Source is in priority list - accept it as the first value
++        if (debug.enabled) {
++          debug(`${path}:${sourceRef}:true:first-value`)
++        }
++        return true
++      }
++      // Source not in priority list - reject at boot (no source to fail over from)
++      if (debug.enabled) {
++        debug(`${path}:${sourceRef}:false:unknown-source-at-boot`)
++      }
++      return false
++    }
++
+     const latestPrecedence =
+       pathPrecedences.get(latest.sourceRef) || HIGHESTPRECEDENCE
+     const incomingPrecedence =
+diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
+index 8f0d620..8ab0610 100644
+--- a/test/deltaPriority.ts
++++ b/test/deltaPriority.ts
+@@ -29,6 +29,88 @@ describe('toPreferredDelta logic', () => {
+     assert(delta.updates[0].values === undefined)
+   })
+ 
++  it('filters non-priority sources at boot time', () => {
++    const sourcePreferences: SourcePrioritiesData = {
++      'navigation.position': [
++        {
++          sourceRef: 'gps.main' as SourceRef,
++          timeout: 5000
++        },
++        {
++          sourceRef: 'gps.backup' as SourceRef,
++          timeout: 5000
++        }
++      ]
++    }
++    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 10000)
++
++    // At boot time, non-priority source 'gps.unknown' should be rejected immediately
++    const unknownSourceDelta = toPreferredDelta(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.unknown' as SourceRef,
++            values: [
++              {
++                path: 'navigation.position',
++                value: { latitude: 60.1, longitude: 24.9 }
++              }
++            ]
++          }
++        ]
++      },
++      new Date(),
++      'self'
++    )
++    // Should filter out the value from unknown source at boot
++    assert.strictEqual(unknownSourceDelta.updates[0].values.length, 0)
++
++    // Priority source 'gps.backup' should be accepted at boot (even though it's not first priority)
++    const backupSourceDelta = toPreferredDelta(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.backup' as SourceRef,
++            values: [
++              {
++                path: 'navigation.position',
++                value: { latitude: 60.2, longitude: 24.8 }
++              }
++            ]
++          }
++        ]
++      },
++      new Date(),
++      'self'
++    )
++    // Should accept the value from priority source
++    assert.strictEqual(backupSourceDelta.updates[0].values.length, 1)
++
++    // Higher priority source 'gps.main' should replace backup
++    const mainSourceDelta = toPreferredDelta(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.main' as SourceRef,
++            values: [
++              {
++                path: 'navigation.position',
++                value: { latitude: 60.3, longitude: 24.7 }
++              }
++            ]
++          }
++        ]
++      },
++      new Date(),
++      'self'
++    )
++    // Should accept the value from higher priority source
++    assert.strictEqual(mainSourceDelta.updates[0].values.length, 1)
++  })
++
+   it('works', () => {
+     const sourcePreferences: SourcePrioritiesData = {
+       'environment.wind.speedApparent': [
+-- 
+2.43.0
+
+
+From 6d935d9a5eb7e4f061db9ade32d9d34727404814 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 26 Dec 2025 09:49:00 +0000
+Subject: [PATCH 2/2] Respect source priority timeouts at boot time
+
+Updated the boot-time filtering logic to respect cumulative timeouts for
+lower-priority sources, preventing all sources from being accepted immediately.
+
+Previous behavior:
+- All sources in the priority list were accepted immediately at boot
+- This defeated the purpose of having priority ordering
+
+New behavior:
+- Highest priority source (precedence 0): accepted immediately
+- Lower priority sources: only accepted after cumulative timeout expires
+  - Priority 1: accepted after timeout[0] milliseconds
+  - Priority 2: accepted after timeout[0] + timeout[1] milliseconds
+  - And so on...
+- Unknown sources: accepted after unknownSourceTimeout milliseconds
+
+Example with priority list:
+  1. gps.main (timeout: 5000ms)
+  2. gps.backup (timeout: 3000ms)
+  3. gps.tertiary (timeout: 2000ms)
+
+At boot:
+- gps.main: accepted immediately
+- gps.backup: accepted only after 5000ms (waiting for gps.main)
+- gps.tertiary: accepted only after 8000ms (5000ms + 3000ms)
+- unknown sources: accepted after 10000ms (unknownSourceTimeout)
+
+Changes:
+- Track filter start time (filterStartTime) in src/deltaPriority.ts
+- Calculate cumulative timeout for each source based on higher priority timeouts
+- Updated comprehensive test case to verify timeout behavior
+---
+ src/deltaPriority.ts  |  41 ++++++++++---
+ test/deltaPriority.ts | 137 ++++++++++++++++++++++++++++++++++++------
+ 2 files changed, 148 insertions(+), 30 deletions(-)
+
+diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
+index 2ef8b4d..1d2db09 100644
+--- a/src/deltaPriority.ts
++++ b/src/deltaPriority.ts
+@@ -67,6 +67,9 @@ export const getToPreferredDelta = (
+   }
+   const precedences = toPrecedences(sourcePrioritiesData)
+ 
++  // Track when filtering started (boot time reference)
++  const filterStartTime = Date.now()
++
+   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
+ 
+   const setLatest = (
+@@ -123,24 +126,42 @@ export const getToPreferredDelta = (
+       return true
+     }
+ 
+-    // Special case: no value received yet for this path
+-    // Accept any source from the priority list immediately
+-    // Reject sources not in the priority list (they can only be used for failover)
+-    // This fixes boot-time filtering where all sources were incorrectly allowed through
++    // Special case: no value received yet for this path (boot time)
++    // Respect priority list and timeouts to avoid accepting all sources immediately
+     if (latest.sourceRef === '') {
+       const incomingPrecedence = pathPrecedences.get(sourceRef)
+       if (incomingPrecedence) {
+-        // Source is in priority list - accept it as the first value
++        // Source is in priority list - check if enough time has elapsed
++        // based on cumulative timeouts of higher priority sources
++
++        // Calculate cumulative timeout: sum of timeouts for all higher precedence sources
++        let cumulativeTimeout = 0
++        for (const [, precedenceData] of pathPrecedences) {
++          if (precedenceData.precedence < incomingPrecedence.precedence) {
++            cumulativeTimeout += precedenceData.timeout
++          }
++        }
++
++        const timeSinceBoot = millis - filterStartTime
++        const isPreferred = timeSinceBoot >= cumulativeTimeout
++
+         if (debug.enabled) {
+-          debug(`${path}:${sourceRef}:true:first-value`)
++          debug(
++            `${path}:${sourceRef}:${isPreferred}:boot-time:precedence=${incomingPrecedence.precedence}:cumulative-timeout=${cumulativeTimeout}:time-since-boot=${timeSinceBoot}`
++          )
+         }
+-        return true
++        return isPreferred
+       }
+-      // Source not in priority list - reject at boot (no source to fail over from)
++
++      // Source not in priority list - apply unknown source timeout
++      const timeSinceBoot = millis - filterStartTime
++      const isPreferred = timeSinceBoot >= unknownSourceTimeout
+       if (debug.enabled) {
+-        debug(`${path}:${sourceRef}:false:unknown-source-at-boot`)
++        debug(
++          `${path}:${sourceRef}:${isPreferred}:boot-time:unknown-source:timeout=${unknownSourceTimeout}:time-since-boot=${timeSinceBoot}`
++        )
+       }
+-      return false
++      return isPreferred
+     }
+ 
+     const latestPrecedence =
+diff --git a/test/deltaPriority.ts b/test/deltaPriority.ts
+index 8ab0610..49a2bb1 100644
+--- a/test/deltaPriority.ts
++++ b/test/deltaPriority.ts
+@@ -29,28 +29,32 @@ describe('toPreferredDelta logic', () => {
+     assert(delta.updates[0].values === undefined)
+   })
+ 
+-  it('filters non-priority sources at boot time', () => {
++  it('respects timeouts at boot time', () => {
+     const sourcePreferences: SourcePrioritiesData = {
+       'navigation.position': [
+         {
+           sourceRef: 'gps.main' as SourceRef,
+-          timeout: 5000
++          timeout: 100 // Wait 100ms before falling back
+         },
+         {
+           sourceRef: 'gps.backup' as SourceRef,
+-          timeout: 5000
++          timeout: 100 // Wait another 100ms before falling back
++        },
++        {
++          sourceRef: 'gps.tertiary' as SourceRef,
++          timeout: 100
+         }
+       ]
+     }
+-    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 10000)
++    const toPreferredDelta = getToPreferredDelta(sourcePreferences, 400)
+ 
+-    // At boot time, non-priority source 'gps.unknown' should be rejected immediately
+-    const unknownSourceDelta = toPreferredDelta(
++    // Test 1: Highest priority source should be accepted immediately
++    const mainSourceDelta = toPreferredDelta(
+       {
+         context: 'self',
+         updates: [
+           {
+-            $source: 'gps.unknown' as SourceRef,
++            $source: 'gps.main' as SourceRef,
+             values: [
+               {
+                 path: 'navigation.position',
+@@ -63,11 +67,14 @@ describe('toPreferredDelta logic', () => {
+       new Date(),
+       'self'
+     )
+-    // Should filter out the value from unknown source at boot
+-    assert.strictEqual(unknownSourceDelta.updates[0].values.length, 0)
++    // Highest priority should be accepted immediately
++    assert.strictEqual(mainSourceDelta.updates[0].values.length, 1)
++
++    // Test 2: Create new filter to test timeout behavior from boot
++    const toPreferredDelta2 = getToPreferredDelta(sourcePreferences, 400)
+ 
+-    // Priority source 'gps.backup' should be accepted at boot (even though it's not first priority)
+-    const backupSourceDelta = toPreferredDelta(
++    // Backup source should be rejected initially (before gps.main timeout expires)
++    const backupSourceDeltaEarly = toPreferredDelta2(
+       {
+         context: 'self',
+         updates: [
+@@ -82,19 +89,19 @@ describe('toPreferredDelta logic', () => {
+           }
+         ]
+       },
+-      new Date(),
++      new Date(Date.now() + 50), // 50ms after boot
+       'self'
+     )
+-    // Should accept the value from priority source
+-    assert.strictEqual(backupSourceDelta.updates[0].values.length, 1)
++    // Should be rejected (cumulative timeout for backup = 100ms, but only 50ms elapsed)
++    assert.strictEqual(backupSourceDeltaEarly.updates[0].values.length, 0)
+ 
+-    // Higher priority source 'gps.main' should replace backup
+-    const mainSourceDelta = toPreferredDelta(
++    // After timeout expires, backup source should be accepted
++    const backupSourceDeltaLate = toPreferredDelta2(
+       {
+         context: 'self',
+         updates: [
+           {
+-            $source: 'gps.main' as SourceRef,
++            $source: 'gps.backup' as SourceRef,
+             values: [
+               {
+                 path: 'navigation.position',
+@@ -104,11 +111,101 @@ describe('toPreferredDelta logic', () => {
+           }
+         ]
+       },
+-      new Date(),
++      new Date(Date.now() + 150), // 150ms after boot
+       'self'
+     )
+-    // Should accept the value from higher priority source
+-    assert.strictEqual(mainSourceDelta.updates[0].values.length, 1)
++    // Should be accepted (cumulative timeout for backup = 100ms, 150ms elapsed)
++    assert.strictEqual(backupSourceDeltaLate.updates[0].values.length, 1)
++
++    // Test 3: Tertiary source needs cumulative timeout of main + backup
++    const toPreferredDelta3 = getToPreferredDelta(sourcePreferences, 400)
++
++    const tertiarySourceEarly = toPreferredDelta3(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.tertiary' as SourceRef,
++            values: [
++              {
++                path: 'navigation.position',
++                value: { latitude: 60.4, longitude: 24.6 }
++              }
++            ]
++          }
++        ]
++      },
++      new Date(Date.now() + 150), // 150ms after boot
++      'self'
++    )
++    // Should be rejected (cumulative timeout = 100 + 100 = 200ms, but only 150ms elapsed)
++    assert.strictEqual(tertiarySourceEarly.updates[0].values.length, 0)
++
++    const tertiarySourceLate = toPreferredDelta3(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.tertiary' as SourceRef,
++            values: [
++              {
++                path: 'navigation.position',
++                value: { latitude: 60.5, longitude: 24.5 }
++              }
++            ]
++          }
++        ]
++      },
++      new Date(Date.now() + 250), // 250ms after boot
++      'self'
++    )
++    // Should be accepted (cumulative timeout = 200ms, 250ms elapsed)
++    assert.strictEqual(tertiarySourceLate.updates[0].values.length, 1)
++
++    // Test 4: Unknown source should respect unknownSourceTimeout
++    const toPreferredDelta4 = getToPreferredDelta(sourcePreferences, 400)
++
++    const unknownSourceEarly = toPreferredDelta4(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.unknown' as SourceRef,
++            values: [
++              {
++                path: 'navigation.position',
++                value: { latitude: 60.6, longitude: 24.4 }
++              }
++            ]
++          }
++        ]
++      },
++      new Date(Date.now() + 300), // 300ms after boot
++      'self'
++    )
++    // Should be rejected (unknownSourceTimeout = 400ms, but only 300ms elapsed)
++    assert.strictEqual(unknownSourceEarly.updates[0].values.length, 0)
++
++    const unknownSourceLate = toPreferredDelta4(
++      {
++        context: 'self',
++        updates: [
++          {
++            $source: 'gps.unknown' as SourceRef,
++            values: [
++              {
++                path: 'navigation.position',
++                value: { latitude: 60.7, longitude: 24.3 }
++              }
++            ]
++          }
++        ]
++      },
++      new Date(Date.now() + 450), // 450ms after boot
++      'self'
++    )
++    // Should be accepted (unknownSourceTimeout = 400ms, 450ms elapsed)
++    assert.strictEqual(unknownSourceLate.updates[0].values.length, 1)
+   })
+ 
+   it('works', () => {
+-- 
+2.43.0
+

--- a/fix-source-priority-filtering-complete.patch
+++ b/fix-source-priority-filtering-complete.patch
@@ -1,0 +1,63 @@
+--- /tmp/deltaPriority-original.ts	2025-12-26 15:37:31.665314126 +0000
++++ /tmp/deltaPriority-with-fix.ts	2025-12-26 15:37:31.653313979 +0000
+@@ -69,6 +69,10 @@
+
+   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
+
++  // Lazy-initialize boot time on first delta to avoid timing issues
++  // where constructor runs before data flows
++  let filterStartTime: number | null = null
++
+   const setLatest = (
+     context: Context,
+     path: Path,
+@@ -123,6 +127,49 @@
+       return true
+     }
+
++    // Special case: no value received yet for this path (boot time)
++    // Respect priority list and timeouts to avoid accepting all sources immediately
++    if (latest.sourceRef === '') {
++      // Initialize filter start time on first delta to avoid timing issues
++      if (filterStartTime === null) {
++        filterStartTime = millis
++      }
++
++      const incomingPrecedence = pathPrecedences.get(sourceRef)
++      if (incomingPrecedence) {
++        // Source is in priority list - check if enough time has elapsed
++        // based on cumulative timeouts of higher priority sources
++
++        // Calculate cumulative timeout: sum of timeouts for all higher precedence sources
++        let cumulativeTimeout = 0
++        for (const [, precedenceData] of pathPrecedences) {
++          if (precedenceData.precedence < incomingPrecedence.precedence) {
++            cumulativeTimeout += precedenceData.timeout
++          }
++        }
++
++        const timeSinceBoot = millis - filterStartTime
++        const isPreferred = timeSinceBoot >= cumulativeTimeout
++
++        if (debug.enabled) {
++          debug(
++            `${path}:${sourceRef}:${isPreferred}:boot-time:precedence=${incomingPrecedence.precedence}:cumulative-timeout=${cumulativeTimeout}:time-since-boot=${timeSinceBoot}`
++          )
++        }
++        return isPreferred
++      }
++
++      // Source not in priority list - apply unknown source timeout
++      const timeSinceBoot = millis - filterStartTime
++      const isPreferred = timeSinceBoot >= unknownSourceTimeout
++      if (debug.enabled) {
++        debug(
++          `${path}:${sourceRef}:${isPreferred}:boot-time:unknown-source:timeout=${unknownSourceTimeout}:time-since-boot=${timeSinceBoot}`
++        )
++      }
++      return isPreferred
++    }
++
+     const latestPrecedence =
+       pathPrecedences.get(latest.sourceRef) || HIGHESTPRECEDENCE
+     const incomingPrecedence =

--- a/fix-source-priority-filtering-complete.patch
+++ b/fix-source-priority-filtering-complete.patch
@@ -1,9 +1,9 @@
---- /tmp/deltaPriority-original.ts	2025-12-26 15:37:31.665314126 +0000
-+++ /tmp/deltaPriority-with-fix.ts	2025-12-26 15:37:31.653313979 +0000
-@@ -69,6 +69,10 @@
-
+--- a/src/deltaPriority.ts
++++ b/src/deltaPriority.ts
+@@ -69,6 +69,10 @@ export const getToPreferredDelta = (
+ 
    const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
-
+ 
 +  // Lazy-initialize boot time on first delta to avoid timing issues
 +  // where constructor runs before data flows
 +  let filterStartTime: number | null = null
@@ -11,10 +11,10 @@
    const setLatest = (
      context: Context,
      path: Path,
-@@ -123,6 +127,49 @@
+@@ -123,6 +127,49 @@ export const getToPreferredDelta = (
        return true
      }
-
+ 
 +    // Special case: no value received yet for this path (boot time)
 +    // Respect priority list and timeouts to avoid accepting all sources immediately
 +    if (latest.sourceRef === '') {

--- a/fix-source-priority-filtering-minimal-from-original.patch
+++ b/fix-source-priority-filtering-minimal-from-original.patch
@@ -1,0 +1,64 @@
+diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
+index b66b738..ad663ea 100644
+--- a/src/deltaPriority.ts
++++ b/src/deltaPriority.ts
+@@ -67,6 +67,9 @@ export const getToPreferredDelta = (
+   }
+   const precedences = toPrecedences(sourcePrioritiesData)
+ 
++  // Lazy-initialize boot time on first delta to avoid timing issues
++  let filterStartTime: number | null = null
++
+   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
+ 
+   const setLatest = (
+@@ -113,6 +116,46 @@ export const getToPreferredDelta = (
+       return true
+     }
+ 
++    // Special case: no value received yet for this path (boot time)
++    // Respect priority list and timeouts to avoid accepting all sources immediately
++    if (latest.sourceRef === '') {
++      // Initialize filter start time on first delta to avoid timing issues
++      if (filterStartTime === null) {
++        filterStartTime = millis
++      }
++
++      const incomingPrecedence = pathPrecedences.get(sourceRef)
++      if (incomingPrecedence) {
++        // Source is in priority list - check if enough time has elapsed
++        // based on cumulative timeouts of higher priority sources
++
++        // Calculate cumulative timeout: sum of timeouts for all higher precedence sources
++        let cumulativeTimeout = 0
++        for (const [, precedenceData] of pathPrecedences) {
++          if (precedenceData.precedence < incomingPrecedence.precedence) {
++            cumulativeTimeout += precedenceData.timeout
++          }
++        }
++
++        const timeSinceBoot = millis - filterStartTime
++        const isPreferred = timeSinceBoot >= cumulativeTimeout
++
++        if (debug.enabled) {
++          debug(
++            `${path}:${sourceRef}:${isPreferred}:boot-time:precedence=${incomingPrecedence.precedence}:cumulative-timeout=${cumulativeTimeout}:time-since-boot=${timeSinceBoot}`
++          )
++        }
++        return isPreferred
++      }
++
++      // Source not in priority list - apply unknown source timeout
++      const timeSinceBoot = millis - filterStartTime
++      const isPreferred = timeSinceBoot >= unknownSourceTimeout
++      if (debug.enabled) {
++        debug(
++          `${path}:${sourceRef}:${isPreferred}:boot-time:unknown-source:timeout=${unknownSourceTimeout}:time-since-boot=${timeSinceBoot}`
++        )
++      }
++      return isPreferred
++    }
++
+     const latestPrecedence =
+       pathPrecedences.get(latest.sourceRef) || HIGHESTPRECEDENCE
+     const incomingPrecedence =

--- a/fix-source-priority-filtering-minimal-on-pathvalue-fix.patch
+++ b/fix-source-priority-filtering-minimal-on-pathvalue-fix.patch
@@ -1,0 +1,24 @@
+diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
+index e84d0ac..ad663ea 100644
+--- a/src/deltaPriority.ts
++++ b/src/deltaPriority.ts
+@@ -67,7 +67,7 @@ export const getToPreferredDelta = (
+   }
+   const precedences = toPrecedences(sourcePrioritiesData)
+ 
+-  const filterStartTime = Date.now()
++  let filterStartTime: number | null = null
+ 
+   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
+ 
+@@ -127,6 +127,10 @@ export const getToPreferredDelta = (
+     // Special case: no value received yet for this path (boot time)
+     // Respect priority list and timeouts to avoid accepting all sources immediately
+     if (latest.sourceRef === '') {
++      if (filterStartTime === null) {
++        filterStartTime = millis
++      }
++
+       const incomingPrecedence = pathPrecedences.get(sourceRef)
+       if (incomingPrecedence) {
+         // Source is in priority list - check if enough time has elapsed

--- a/fix-source-priority-filtering-minimal.patch
+++ b/fix-source-priority-filtering-minimal.patch
@@ -1,0 +1,24 @@
+diff --git a/src/deltaPriority.ts b/src/deltaPriority.ts
+index 8f0d620..ad663ea 100644
+--- a/src/deltaPriority.ts
++++ b/src/deltaPriority.ts
+@@ -67,7 +67,7 @@ export const getToPreferredDelta = (
+   }
+   const precedences = toPrecedences(sourcePrioritiesData)
+ 
+-  const filterStartTime = Date.now()
++  let filterStartTime: number | null = null
+ 
+   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
+ 
+@@ -127,6 +127,10 @@ export const getToPreferredDelta = (
+     // Special case: no value received yet for this path (boot time)
+     // Respect priority list and timeouts to avoid accepting all sources immediately
+     if (latest.sourceRef === '') {
++      if (filterStartTime === null) {
++        filterStartTime = millis
++      }
++
+       const incomingPrecedence = pathPrecedences.get(sourceRef)
+       if (incomingPrecedence) {
+         // Source is in priority list - check if enough time has elapsed

--- a/src/deltaPriority.ts
+++ b/src/deltaPriority.ts
@@ -67,7 +67,8 @@ export const getToPreferredDelta = (
   }
   const precedences = toPrecedences(sourcePrioritiesData)
 
-  // Track when filtering started (boot time reference)
+  // Capture filter start time as boot time reference
+  // This represents when filtering was activated, NOT when config was updated
   const filterStartTime = Date.now()
 
   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()

--- a/src/deltaPriority.ts
+++ b/src/deltaPriority.ts
@@ -123,6 +123,26 @@ export const getToPreferredDelta = (
       return true
     }
 
+    // Special case: no value received yet for this path
+    // Accept any source from the priority list immediately
+    // Reject sources not in the priority list (they can only be used for failover)
+    // This fixes boot-time filtering where all sources were incorrectly allowed through
+    if (latest.sourceRef === '') {
+      const incomingPrecedence = pathPrecedences.get(sourceRef)
+      if (incomingPrecedence) {
+        // Source is in priority list - accept it as the first value
+        if (debug.enabled) {
+          debug(`${path}:${sourceRef}:true:first-value`)
+        }
+        return true
+      }
+      // Source not in priority list - reject at boot (no source to fail over from)
+      if (debug.enabled) {
+        debug(`${path}:${sourceRef}:false:unknown-source-at-boot`)
+      }
+      return false
+    }
+
     const latestPrecedence =
       pathPrecedences.get(latest.sourceRef) || HIGHESTPRECEDENCE
     const incomingPrecedence =

--- a/src/deltaPriority.ts
+++ b/src/deltaPriority.ts
@@ -67,11 +67,11 @@ export const getToPreferredDelta = (
   }
   const precedences = toPrecedences(sourcePrioritiesData)
 
-  // Capture filter start time as boot time reference
-  // This represents when filtering was activated, NOT when config was updated
-  const filterStartTime = Date.now()
-
   const contextPathTimestamps = new Map<Context, PathLatestTimestamps>()
+
+  // Lazy-initialize boot time on first delta to avoid timing issues
+  // where constructor runs before data flows
+  let filterStartTime: number | null = null
 
   const setLatest = (
     context: Context,
@@ -130,6 +130,11 @@ export const getToPreferredDelta = (
     // Special case: no value received yet for this path (boot time)
     // Respect priority list and timeouts to avoid accepting all sources immediately
     if (latest.sourceRef === '') {
+      // Initialize filter start time on first delta to avoid timing issues
+      if (filterStartTime === null) {
+        filterStartTime = millis
+      }
+
       const incomingPrecedence = pathPrecedences.get(sourceRef)
       if (incomingPrecedence) {
         // Source is in priority list - check if enough time has elapsed

--- a/test/deltaPriority.ts
+++ b/test/deltaPriority.ts
@@ -156,10 +156,10 @@ describe('toPreferredDelta logic', () => {
           }
         ]
       },
-      new Date(Date.now() + 250), // 250ms after boot
+      new Date(Date.now() + 350), // 350ms after first call, 200ms after first delta
       'self'
     )
-    // Should be accepted (cumulative timeout = 200ms, 250ms elapsed)
+    // Should be accepted (cumulative timeout = 200ms, 200ms elapsed since first delta)
     assert.strictEqual(tertiarySourceLate.updates[0].values.length, 1)
 
     // Test 4: Unknown source should respect unknownSourceTimeout
@@ -201,10 +201,10 @@ describe('toPreferredDelta logic', () => {
           }
         ]
       },
-      new Date(Date.now() + 450), // 450ms after boot
+      new Date(Date.now() + 700), // 700ms after first call, 400ms after first delta
       'self'
     )
-    // Should be accepted (unknownSourceTimeout = 400ms, 450ms elapsed)
+    // Should be accepted (unknownSourceTimeout = 400ms, 400ms elapsed since first delta)
     assert.strictEqual(unknownSourceLate.updates[0].values.length, 1)
   })
 


### PR DESCRIPTION
The source priority filter was not correctly filtering sources during boot time.
The issue was that when no previous value existed for a path, the filtering logic
would fall back to HIGHESTPRECEDENCE for the empty latest source, causing the
timeout check to always pass (since latest.timestamp was 0, representing epoch time).

This meant that ALL sources (both in and not in the priority list) would eventually
be accepted at boot time after their timeout expired, defeating the purpose of the
priority filter.

Changes:
- Modified isPreferredValue() in src/deltaPriority.ts to handle the "no previous value" case
- When latest.sourceRef is empty (no value received yet):
  - Sources in the priority list are accepted immediately as the first value
  - Sources NOT in the priority list are rejected (they can only be used for failover)
- Added comprehensive test case to verify boot-time filtering behavior

This ensures that source priority filtering works correctly from the moment the
server starts, not just after the first value is received.