### PR TITLE
Show human-readable WS device names in Dashboard, Data Browser, and Source Priorities

### DIFF
--- a/packages/server-admin-ui-react19/src/hooks/sourceLabelUtils.test.ts
+++ b/packages/server-admin-ui-react19/src/hooks/sourceLabelUtils.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { getSourceDisplayLabel } from './sourceLabelUtils'
+
+describe('sourceLabelUtils', () => {
+  it('uses n2k description for nested ws source refs', () => {
+    const sources = {
+      ws: {
+        myDevice: {
+          n2k: {
+            description: 'Cabin Tablet'
+          }
+        }
+      }
+    }
+
+    expect(getSourceDisplayLabel('ws.myDevice.n2k.204', sources)).toBe(
+      'Cabin Tablet'
+    )
+  })
+
+  it('falls back to sourceRef when ws n2k description is missing', () => {
+    const sources = {
+      ws: {
+        myDevice: {
+          description: 'Top-level only'
+        }
+      }
+    }
+
+    expect(getSourceDisplayLabel('ws.myDevice.n2k.204', sources)).toBe(
+      'ws.myDevice.n2k.204'
+    )
+  })
+
+  it('falls back to sourceRef for non-ws source refs', () => {
+    const sources = {
+      nmea0183: {
+        tcp: {
+          description: 'NMEA tcp'
+        }
+      }
+    }
+
+    expect(getSourceDisplayLabel('nmea0183.tcp', sources)).toBe('nmea0183.tcp')
+  })
+})

--- a/packages/server-admin-ui-react19/src/hooks/sourceLabelUtils.ts
+++ b/packages/server-admin-ui-react19/src/hooks/sourceLabelUtils.ts
@@ -1,0 +1,38 @@
+interface SourceMetadata {
+  n2k?: {
+    description?: string
+  }
+  [key: string]: unknown
+}
+
+function getWsSourceMetadata(
+  sourceRef: string,
+  sources: Record<string, unknown>
+): SourceMetadata | null {
+  if (!sourceRef?.startsWith('ws.') || !sources || typeof sources !== 'object') {
+    return null
+  }
+
+  const parts = sourceRef.split('.')
+  const wsDeviceId = parts[1]
+  if (!wsDeviceId) {
+    return null
+  }
+
+  const wsSources = sources.ws
+  if (!wsSources || typeof wsSources !== 'object') {
+    return null
+  }
+
+  const node = (wsSources as Record<string, unknown>)[wsDeviceId]
+  return node && typeof node === 'object' ? (node as SourceMetadata) : null
+}
+
+export function getSourceDisplayLabel(
+  sourceRef: string,
+  sources: Record<string, unknown> = {}
+): string {
+  const metadata = getWsSourceMetadata(sourceRef, sources)
+  const description = metadata?.n2k?.description
+  return description || sourceRef
+}

--- a/packages/server-admin-ui-react19/src/hooks/useSources.ts
+++ b/packages/server-admin-ui-react19/src/hooks/useSources.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react'
+
+export function fetchSourcesData(): Promise<Record<string, unknown>> {
+  return fetch('/signalk/v1/api/sources', {
+    credentials: 'include'
+  }).then((response) => response.json())
+}
+
+export function useSources(pollInterval = 30000): Record<string, unknown> {
+  const [sources, setSources] = useState<Record<string, unknown>>({})
+
+  useEffect(() => {
+    let canceled = false
+
+    const doFetch = () => {
+      fetchSourcesData()
+        .then((data) => {
+          if (!canceled) {
+            setSources(data)
+          }
+        })
+        .catch(() => undefined)
+    }
+
+    doFetch()
+    const interval =
+      pollInterval > 0 ? setInterval(doFetch, pollInterval) : null
+
+    return () => {
+      canceled = true
+      if (interval) clearInterval(interval)
+    }
+  }, [pollInterval])
+
+  return sources
+}

--- a/packages/server-admin-ui-react19/src/views/Dashboard/Dashboard.tsx
+++ b/packages/server-admin-ui-react19/src/views/Dashboard/Dashboard.tsx
@@ -10,6 +10,8 @@ import { faSignIn } from '@fortawesome/free-solid-svg-icons/faSignIn'
 import { faSignOut } from '@fortawesome/free-solid-svg-icons/faSignOut'
 import { useServerStats, useWsStatus, useStore } from '../../store'
 import type { ProviderStatistics } from '../../store/types'
+import { useSources } from '../../hooks/useSources'
+import { getSourceDisplayLabel } from '../../hooks/sourceLabelUtils'
 import '../../fa-pulse.css'
 
 interface ProviderStatusItem {
@@ -27,6 +29,7 @@ export default function Dashboard() {
   const providerStatus =
     (useStore((state) => state.providerStatus) as ProviderStatusItem[]) || []
   const navigate = useNavigate()
+  const sources = useSources()
 
   const deltaRate = serverStatistics?.deltaRate ?? 0
   const numberOfAvailablePaths = serverStatistics?.numberOfAvailablePaths ?? 0
@@ -74,6 +77,7 @@ export default function Dashboard() {
     providerStats: ProviderStatistics,
     linkType: string
   ): ReactNode => {
+    const label = getSourceDisplayLabel(providerId, sources)
     const iconStyle = {
       fontSize: '18px',
       marginLeft: '5px',
@@ -100,7 +104,7 @@ export default function Dashboard() {
         <span className="title">
           {linkType === 'plugin'
             ? pluginNameLink(providerId)
-            : providerIdLink(providerId)}
+            : providerIdLink(providerId, label)}
         </span>
         {(providerStats.writeRate || 0) > 0 && (
           <span className="value" style={{ fontWeight: 'normal' }}>
@@ -160,7 +164,10 @@ export default function Dashboard() {
         <td>
           {status.statusType === 'plugin'
             ? pluginNameLink(status.id)
-            : providerIdLink(status.id)}
+            : providerIdLink(
+                status.id,
+                getSourceDisplayLabel(status.id, sources)
+              )}
         </td>
         <td>
           <p className="text-danger">{lastError}</p>
@@ -313,11 +320,11 @@ function pluginNameLink(id: string): ReactNode {
   return <a href={'#/serverConfiguration/plugins/' + id}>{id}</a>
 }
 
-function providerIdLink(id: string): ReactNode {
+function providerIdLink(id: string, label?: string): ReactNode {
   if (id === 'defaults') {
     return <a href={'#/serverConfiguration/settings'}>{id}</a>
   } else if (id.startsWith('ws.')) {
-    return <a href={'#/security/devices'}>{id}</a>
+    return <a href={'#/security/devices'}>{label || id}</a>
   } else {
     return <a href={'#/serverConfiguration/connections/' + id}>{id}</a>
   }

--- a/packages/server-admin-ui-react19/src/views/DataBrowser/DataRow.tsx
+++ b/packages/server-admin-ui-react19/src/views/DataBrowser/DataRow.tsx
@@ -3,6 +3,7 @@ import { usePathData, useMetaData } from './usePathData'
 import TimestampCell from './TimestampCell'
 import CopyToClipboardWithFade from './CopyToClipboardWithFade'
 import { getValueRenderer, DefaultValueRenderer } from './ValueRenderers'
+import { getSourceDisplayLabel } from '../../hooks/sourceLabelUtils'
 import type { PathData, MetaData } from '../../store'
 
 interface DataRowProps {
@@ -14,6 +15,7 @@ interface DataRowProps {
   onToggleSource: (source: string) => void
   selectedSources: Set<string>
   showContext: boolean
+  sources: Record<string, unknown>
 }
 
 interface ValueRendererProps {
@@ -31,7 +33,8 @@ function DataRow({
   isPaused,
   onToggleSource,
   selectedSources,
-  showContext
+  showContext,
+  sources
 }: DataRowProps) {
   // When showContext is true, path$SourceKey is a composite key: context\0realKey
   const nullIdx = showContext ? path$SourceKey.indexOf('\0') : -1
@@ -122,7 +125,8 @@ function DataRow({
           />
         </label>
         <CopyToClipboardWithFade text={source}>
-          {source} <span className="copy-icon" aria-hidden="true" />
+          {getSourceDisplayLabel(source, sources)}{' '}
+          <span className="copy-icon" aria-hidden="true" />
         </CopyToClipboardWithFade>{' '}
         {data.pgn && <span>&nbsp;{data.pgn}</span>}
         {data.sentence && <span>&nbsp;{data.sentence}</span>}

--- a/packages/server-admin-ui-react19/src/views/DataBrowser/VirtualizedDataTable.tsx
+++ b/packages/server-admin-ui-react19/src/views/DataBrowser/VirtualizedDataTable.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 import DataRow from './DataRow'
 import granularSubscriptionManager from './GranularSubscriptionManager'
+import { useSources } from '../../hooks/useSources'
 import './VirtualTable.css'
 
 interface VisibleItem {
@@ -38,6 +39,7 @@ function VirtualizedDataTable({
   sourceFilterActive,
   showContext
 }: VirtualizedDataTableProps) {
+  const sources = useSources()
   const containerRef = useRef<HTMLDivElement>(null)
   const [isNarrowScreen, setIsNarrowScreen] = useState(
     typeof window !== 'undefined' && window.innerWidth <= 768
@@ -236,6 +238,7 @@ function VirtualizedDataTable({
             onToggleSource={onToggleSource}
             selectedSources={selectedSources}
             showContext={showContext}
+            sources={sources}
           />
         ))}
 

--- a/packages/server-admin-ui-react19/src/views/ServerConfig/SourcePriorities.tsx
+++ b/packages/server-admin-ui-react19/src/views/ServerConfig/SourcePriorities.tsx
@@ -14,6 +14,8 @@ import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk'
 import Creatable from 'react-select/creatable'
 import uniq from 'lodash.uniq'
 import { useStore, useSourcePriorities } from '../../store'
+import { useSources } from '../../hooks/useSources'
+import { getSourceDisplayLabel } from '../../hooks/sourceLabelUtils'
 
 // Types
 interface Priority {
@@ -51,13 +53,15 @@ interface PrefsEditorProps {
   priorities: Priority[]
   pathIndex: number
   isSaving: boolean
+  sources: Record<string, unknown>
 }
 
 const PrefsEditor: React.FC<PrefsEditorProps> = ({
   path,
   priorities,
   pathIndex,
-  isSaving
+  isSaving,
+  sources
 }) => {
   const changePriority = useStore((s) => s.changePriority)
   const deletePriority = useStore((s) => s.deletePriority)
@@ -76,8 +80,11 @@ const PrefsEditor: React.FC<PrefsEditorProps> = ({
 
   const toggleEditor = () => setIsOpen((prev) => !prev)
 
+  const resolveSourceLabel = (ref: string): string =>
+    getSourceDisplayLabel(ref, sources)
+
   const options: SelectOption[] = sourceRefs.map((ref) => ({
-    label: ref,
+    label: resolveSourceLabel(ref),
     value: ref
   }))
 
@@ -107,7 +114,7 @@ const PrefsEditor: React.FC<PrefsEditorProps> = ({
                       <Creatable
                         menuPortalTarget={document.body}
                         options={options}
-                        value={{ value: sourceRef, label: sourceRef }}
+                        value={{ value: sourceRef, label: resolveSourceLabel(sourceRef) }}
                         onChange={(e) => {
                           changePriority(
                             pathIndex,
@@ -199,6 +206,7 @@ const SourcePriorities: React.FC = () => {
   const { sourcePriorities, saveState } = sourcePrioritiesData
 
   const [availablePaths, setAvailablePaths] = useState<SelectOption[]>([])
+  const sources = useSources()
 
   useEffect(() => {
     fetchAvailablePaths((pathsArray) => {
@@ -312,6 +320,7 @@ const SourcePriorities: React.FC = () => {
                       priorities={priorities}
                       pathIndex={index}
                       isSaving={saveState.isSaving || false}
+                      sources={sources}
                     />
                   </td>
                   <td style={{ border: 'none' }}>

--- a/packages/server-admin-ui/src/utils/sourceLabelUtils.js
+++ b/packages/server-admin-ui/src/utils/sourceLabelUtils.js
@@ -1,0 +1,29 @@
+function getWsSourceMetadata(sourceRef, sources) {
+  if (
+    !sourceRef?.startsWith('ws.') ||
+    !sources ||
+    typeof sources !== 'object'
+  ) {
+    return null
+  }
+
+  const parts = sourceRef.split('.')
+  const wsDeviceId = parts[1]
+  if (!wsDeviceId) {
+    return null
+  }
+
+  const wsSources = sources.ws
+  if (!wsSources || typeof wsSources !== 'object') {
+    return null
+  }
+
+  const node = wsSources[wsDeviceId]
+  return node && typeof node === 'object' ? node : null
+}
+
+export function getSourceDisplayLabel(sourceRef, sources = {}) {
+  const metadata = getWsSourceMetadata(sourceRef, sources)
+  const description = metadata?.n2k?.description
+  return description || sourceRef
+}

--- a/packages/server-admin-ui/src/utils/useSources.js
+++ b/packages/server-admin-ui/src/utils/useSources.js
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react'
+
+export function fetchSourcesData() {
+  return fetch('/signalk/v1/api/sources', {
+    credentials: 'include'
+  }).then((response) => response.json())
+}
+
+export function useSources(pollInterval = 30000) {
+  const [sources, setSources] = useState({})
+
+  useEffect(() => {
+    let canceled = false
+
+    const doFetch = () => {
+      fetchSourcesData()
+        .then((data) => {
+          if (!canceled) {
+            setSources(data)
+          }
+        })
+        .catch(() => undefined)
+    }
+
+    doFetch()
+    const interval = pollInterval > 0
+      ? setInterval(doFetch, pollInterval)
+      : null
+
+    return () => {
+      canceled = true
+      if (interval) clearInterval(interval)
+    }
+  }, [pollInterval])
+
+  return sources
+}

--- a/packages/server-admin-ui/src/views/Dashboard/Dashboard.js
+++ b/packages/server-admin-ui/src/views/Dashboard/Dashboard.js
@@ -10,8 +10,12 @@ import {
   Table
 } from 'reactstrap'
 import '../../fa-pulse.css'
+import { getSourceDisplayLabel } from '../../utils/sourceLabelUtils'
+import { useSources } from '../../utils/useSources'
 
 const Dashboard = (props) => {
+  const sources = useSources()
+
   const {
     deltaRate,
     numberOfAvailablePaths,
@@ -66,6 +70,7 @@ const Dashboard = (props) => {
   }
 
   const renderActivity = (providerId, providerStats, linkType) => {
+    const label = getSourceDisplayLabel(providerId, sources)
     return (
       <li key={providerId} onClick={() => props.history.push(`/dashboard`)}>
         <i
@@ -84,7 +89,7 @@ const Dashboard = (props) => {
         <span className="title">
           {linkType === 'plugin'
             ? pluginNameLink(providerId)
-            : providerIdLink(providerId)}
+            : providerIdLink(providerId, label)}
         </span>
         {providerStats.writeRate > 0 && (
           <span className="value">
@@ -136,7 +141,10 @@ const Dashboard = (props) => {
         <td>
           {status.statusType === 'plugin'
             ? pluginNameLink(status.id)
-            : providerIdLink(status.id)}
+            : providerIdLink(
+                status.id,
+                getSourceDisplayLabel(status.id, sources)
+              )}
         </td>
         <td>
           <p className="text-danger">{lastError}</p>
@@ -286,11 +294,11 @@ function pluginNameLink(id) {
   return <a href={'#/serverConfiguration/plugins/' + id}>{id}</a>
 }
 
-function providerIdLink(id) {
+function providerIdLink(id, label) {
   if (id === 'defaults') {
     return <a href={'#/serverConfiguration/settings'}>{id}</a>
   } else if (id.startsWith('ws.')) {
-    return <a href={'#/security/devices'}>{id}</a>
+    return <a href={'#/security/devices'}>{label || id}</a>
   } else {
     return <a href={'#/serverConfiguration/connections/' + id}>{id}</a>
   }

--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { JSONTree } from 'react-json-tree'
 import Select from 'react-select'
+import { fetchSourcesData } from '../../utils/useSources'
 import {
   Card,
   CardHeader,
@@ -32,10 +33,7 @@ const selectedSourcesStorageKey = 'admin.v1.dataBrowser.selectedSources'
 const sourceFilterActiveStorageKey = 'admin.v1.dataBrowser.sourceFilterActive'
 
 function fetchSources() {
-  fetch(`/signalk/v1/api/sources`, {
-    credentials: 'include'
-  })
-    .then((response) => response.json())
+  fetchSourcesData()
     .then((sources) => {
       Object.values(sources).forEach((source) => {
         if (source.type === 'NMEA2000') {

--- a/packages/server-admin-ui/src/views/DataBrowser/DataRow.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataRow.js
@@ -3,6 +3,7 @@ import { usePathData, useMetaData } from './usePathData'
 import TimestampCell from './TimestampCell'
 import CopyToClipboardWithFade from './CopyToClipboardWithFade'
 import { getValueRenderer, DefaultValueRenderer } from './ValueRenderers'
+import { getSourceDisplayLabel } from '../../utils/sourceLabelUtils'
 
 /**
  * DataRow - Individual virtualized row with granular subscription
@@ -15,7 +16,8 @@ function DataRow({
   raw,
   isPaused,
   onToggleSource,
-  selectedSources
+  selectedSources,
+  sources
 }) {
   const data = usePathData(context, path$SourceKey)
   const meta = useMetaData(context, data?.path)
@@ -73,7 +75,8 @@ function DataRow({
           }}
         />
         <CopyToClipboardWithFade text={data.$source}>
-          {data.$source} <i className="far fa-copy"></i>
+          {getSourceDisplayLabel(data.$source, sources)}{' '}
+          <i className="far fa-copy"></i>
         </CopyToClipboardWithFade>
         {data.pgn && <span>&nbsp;{data.pgn}</span>}
         {data.sentence && <span>&nbsp;{data.sentence}</span>}

--- a/packages/server-admin-ui/src/views/DataBrowser/VirtualizedDataTable.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/VirtualizedDataTable.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react'
 import DataRow from './DataRow'
 import granularSubscriptionManager from './GranularSubscriptionManager'
+import { useSources } from '../../utils/useSources'
 import './VirtualTable.css'
 
 /**
@@ -17,6 +18,7 @@ function VirtualizedDataTable({
   onToggleSourceFilter,
   sourceFilterActive
 }) {
+  const sources = useSources()
   const containerRef = useRef(null)
   const [visibleRange, setVisibleRange] = useState({ start: 0, end: 50 })
   const [isNarrowScreen, setIsNarrowScreen] = useState(
@@ -236,6 +238,7 @@ function VirtualizedDataTable({
             isPaused={isPaused}
             onToggleSource={onToggleSource}
             selectedSources={selectedSources}
+            sources={sources}
           />
         ))}
 

--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -17,7 +17,11 @@ const _ = require('lodash')
 const ports = require('../ports')
 const cookie = require('cookie')
 const { getSourceId, getMetadata } = require('@signalk/signalk-schema')
-const { requestAccess, InvalidTokenError } = require('../security')
+const {
+  requestAccess,
+  InvalidTokenError,
+  getSecurityConfig
+} = require('../security')
 const {
   findRequest,
   updateRequest,
@@ -44,6 +48,84 @@ const BACKPRESSURE_ENTER_THRESHOLD = process.env.BACKPRESSURE_ENTER
 const BACKPRESSURE_EXIT_THRESHOLD = process.env.BACKPRESSURE_EXIT
   ? parseInt(process.env.BACKPRESSURE_EXIT, 10)
   : 1024
+
+function wsSourceRefFromIdentifier(identifier) {
+  return `ws.${identifier.replace(/\./g, '_')}`
+}
+
+const wsDeviceDescriptionCache = new Map()
+
+function getWsDeviceDescription(app, identifier) {
+  if (
+    !identifier ||
+    identifier === 'AUTO' ||
+    !app.securityStrategy ||
+    typeof app.securityStrategy.getDevices !== 'function'
+  ) {
+    return undefined
+  }
+
+  const cached = wsDeviceDescriptionCache.get(identifier)
+  if (cached !== undefined) {
+    return cached || undefined
+  }
+
+  try {
+    const config = getSecurityConfig(app)
+    const devices = app.securityStrategy.getDevices(config)
+    if (!Array.isArray(devices)) {
+      wsDeviceDescriptionCache.set(identifier, null)
+      return undefined
+    }
+    const device = devices.find((candidate) => candidate.clientId === identifier)
+    const description =
+      device && device.description ? device.description : undefined
+    wsDeviceDescriptionCache.set(identifier, description || null)
+    return description
+  } catch (error) {
+    debugConnection(
+      `could not resolve ws device description for ${identifier}: ${
+        error && error.message ? error.message : error
+      }`
+    )
+    wsDeviceDescriptionCache.set(identifier, null)
+    return undefined
+  }
+}
+
+function publishWsDeviceSourceMetadata(app, identifier) {
+  if (!app.deltaCache || typeof app.deltaCache.setSourceDelta !== 'function') {
+    return
+  }
+
+  const sourceRef = wsSourceRefFromIdentifier(identifier)
+  if (sourceRef in app.deltaCache.sourceDeltas) {
+    return
+  }
+
+  const description = getWsDeviceDescription(app, identifier)
+  if (!description) {
+    return
+  }
+
+  const sourceDelta = {
+    context: app.selfContext,
+    updates: [
+      {
+        source: {
+          label: 'ws',
+          src: sourceRef.substring(3),
+          type: 'ws',
+          description
+        },
+        timestamp: new Date().toISOString(),
+        values: []
+      }
+    ]
+  }
+
+  app.deltaCache.setSourceDelta(sourceRef, sourceDelta)
+}
 
 module.exports = function (app) {
   'use strict'
@@ -186,6 +268,7 @@ module.exports = function (app) {
         let principalId
         if (spark.request.skPrincipal) {
           principalId = spark.request.skPrincipal.identifier
+          publishWsDeviceSourceMetadata(app, principalId)
         }
 
         debugConnection(
@@ -288,7 +371,7 @@ module.exports = function (app) {
               }
 
               if (msg.accessRequest) {
-                processAccessRequest(spark, msg)
+                processAccessRequest(app, spark, msg)
               }
 
               if (msg.login && app.securityStrategy.supportsLogin()) {
@@ -438,7 +521,7 @@ module.exports = function (app) {
     })
   }
 
-  function processAccessRequest(spark, msg) {
+  function processAccessRequest(app, spark, msg) {
     if (spark.skPendingAccessRequest) {
       spark.write({
         requestId: msg.requestId,
@@ -461,8 +544,13 @@ module.exports = function (app) {
             if (res.accessRequest && res.accessRequest.token) {
               spark.request.token = res.accessRequest.token
               app.securityStrategy.authorizeWS(spark.request)
-              spark.request.source =
-                'ws.' + spark.request.skPrincipal.identifier.replace(/\./g, '_')
+              spark.request.source = wsSourceRefFromIdentifier(
+                spark.request.skPrincipal.identifier
+              )
+              publishWsDeviceSourceMetadata(
+                app,
+                spark.request.skPrincipal.identifier
+              )
             }
           }
           spark.write(res)
@@ -531,7 +619,7 @@ function createPrimusAuthorize(authorizeWS) {
       const identifier = _.get(req, 'skPrincipal.identifier')
       if (identifier) {
         debug(`authorized username: ${identifier}`)
-        req.source = 'ws.' + identifier.replace(/\./g, '_')
+        req.source = wsSourceRefFromIdentifier(identifier)
       }
     } catch (error) {
       // To be able to login or request access via WS with security in place


### PR DESCRIPTION
This fixes WS sources being shown as raw [ws.<id>](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/karl-/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#) references in both admin UIs, which made source identification hard in daily use.

The approach is to ensure WS device descriptions are published into /signalk/v1/api/sources metadata and then consistently resolve display labels from that metadata in both server-admin-ui and server-admin-ui-react19, with safe fallback to the original source ref when no label is available.

This keeps behavior backward compatible, keeps source metadata under the expected n2k path for display resolution, and avoids unnecessary extra work by reusing shared source-fetch utilities and cached WS metadata lookup.

Validation was added for both UI label resolution and security/device flow so source descriptions end up in the expected place for rendering.