### PR TITLE
Fix Vite mixed import warnings by extracting data-fetching module

### DIFF
--- a/packages/server-admin-ui/src/actions.ts
+++ b/packages/server-admin-ui/src/actions.ts
@@ -1,19 +1,8 @@
-import { isUndefined } from 'lodash'
 import { webSocketService } from './services/WebSocketService'
 import { useStore } from './store'
+import { authFetch, fetchAllData, fetchLoginStatus } from './dataFetching'
 
-declare global {
-  interface Window {
-    serverRoutesPrefix: string
-  }
-}
-
-const authFetch = (url: string, options?: RequestInit): Promise<Response> => {
-  return fetch(url, {
-    ...options,
-    credentials: 'include'
-  })
-}
+export { fetchAllData, fetchLoginStatus }
 
 export async function logoutAction(): Promise<void> {
   try {
@@ -157,48 +146,6 @@ export async function checkSecurityBackup(): Promise<boolean> {
     return data.hasBackup === true
   }
   return false
-}
-
-export async function fetchLoginStatus(): Promise<void> {
-  const response = await authFetch(`${window.serverRoutesPrefix}/loginStatus`)
-  if (response.status === 200) {
-    const data = await response.json()
-    useStore.getState().setLoginStatus(data)
-  }
-}
-
-export async function fetchAllData(): Promise<void> {
-  const fetchAndSet = async <T>(
-    endpoint: string,
-    setter: (data: T) => void,
-    prefix?: string
-  ) => {
-    try {
-      const response = await authFetch(
-        `${isUndefined(prefix) ? window.serverRoutesPrefix : prefix}${endpoint}`
-      )
-      if (response.status === 200) {
-        const data = await response.json()
-        setter(data)
-      }
-    } catch (error) {
-      console.error(`Failed to fetch ${endpoint}:`, error)
-    }
-  }
-
-  const state = useStore.getState()
-
-  await Promise.all([
-    fetchAndSet('/plugins', state.setPlugins),
-    fetchAndSet('/webapps', state.setWebapps),
-    fetchAndSet('/addons', state.setAddons),
-    fetchAndSet('/appstore/available', state.setAppStore),
-    fetchAndSet('/loginStatus', state.setLoginStatus),
-    fetchAndSet('/signalk', state.setServerSpecification, ''),
-    fetchAndSet('/security/access/requests', state.setAccessRequests),
-    fetchAndSet('/security/devices', state.setDevices),
-    fetchAndSet('/nodeInfo', state.setNodeInfo)
-  ])
 }
 
 export function openServerEventsConnection(isReconnect?: boolean): void {

--- a/packages/server-admin-ui/src/dataFetching.ts
+++ b/packages/server-admin-ui/src/dataFetching.ts
@@ -1,0 +1,60 @@
+import { isUndefined } from 'lodash'
+import { useStore } from './store'
+
+declare global {
+  interface Window {
+    serverRoutesPrefix: string
+  }
+}
+
+export const authFetch = (
+  url: string,
+  options?: RequestInit
+): Promise<Response> => {
+  return fetch(url, {
+    ...options,
+    credentials: 'include'
+  })
+}
+
+export async function fetchLoginStatus(): Promise<void> {
+  const response = await authFetch(`${window.serverRoutesPrefix}/loginStatus`)
+  if (response.status === 200) {
+    const data = await response.json()
+    useStore.getState().setLoginStatus(data)
+  }
+}
+
+export async function fetchAllData(): Promise<void> {
+  const fetchAndSet = async <T>(
+    endpoint: string,
+    setter: (data: T) => void,
+    prefix?: string
+  ) => {
+    try {
+      const response = await authFetch(
+        `${isUndefined(prefix) ? window.serverRoutesPrefix : prefix}${endpoint}`
+      )
+      if (response.status === 200) {
+        const data = await response.json()
+        setter(data)
+      }
+    } catch (error) {
+      console.error(`Failed to fetch ${endpoint}:`, error)
+    }
+  }
+
+  const state = useStore.getState()
+
+  await Promise.all([
+    fetchAndSet('/plugins', state.setPlugins),
+    fetchAndSet('/webapps', state.setWebapps),
+    fetchAndSet('/addons', state.setAddons),
+    fetchAndSet('/appstore/available', state.setAppStore),
+    fetchAndSet('/loginStatus', state.setLoginStatus),
+    fetchAndSet('/signalk', state.setServerSpecification, ''),
+    fetchAndSet('/security/access/requests', state.setAccessRequests),
+    fetchAndSet('/security/devices', state.setDevices),
+    fetchAndSet('/nodeInfo', state.setNodeInfo)
+  ])
+}

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -1,4 +1,5 @@
-import type { SignalKStore } from '../store'
+import { useStore, type SignalKStore } from '../store'
+import { fetchAllData } from '../dataFetching'
 
 export type WebSocketStatus =
   | 'initial'
@@ -66,10 +67,8 @@ export class WebSocketService {
       this.updateState({ status: 'open', ws })
 
       if (isReconnect) {
-        import('../actions').then(({ fetchAllData }) => fetchAllData())
-        import('../store').then(({ useStore }) =>
-          useStore.getState().setRestarting(false)
-        )
+        fetchAllData()
+        useStore.getState().setRestarting(false)
       }
     }
 
@@ -225,17 +224,15 @@ export class WebSocketService {
           }
         }))
         break
-      case 'LOG':
-        // Dynamic import avoids circular dependency with store
-        import('../store').then(({ useStore }) => {
-          const logData = msg.data as {
-            isError?: boolean
-            ts: string
-            row: string
-          }
-          useStore.getState().addLogEntry(logData)
-        })
+      case 'LOG': {
+        const logData = msg.data as {
+          isError?: boolean
+          ts: string
+          row: string
+        }
+        useStore.getState().addLogEntry(logData)
         break
+      }
       case 'ACCESS_REQUEST':
         this.zustandSetState({ accessRequests: data } as Partial<SignalKStore>)
         break
@@ -251,29 +248,22 @@ export class WebSocketService {
         this.zustandSetState({ restoreStatus: data } as Partial<SignalKStore>)
         break
       case 'VESSEL_INFO':
-        import('../store').then(({ useStore }) => {
-          useStore
-            .getState()
-            .setVesselInfo(data as Parameters<SignalKStore['setVesselInfo']>[0])
-        })
+        useStore
+          .getState()
+          .setVesselInfo(data as Parameters<SignalKStore['setVesselInfo']>[0])
         break
       case 'SOURCEPRIORITIES':
-        import('../store').then(({ useStore }) => {
-          useStore
-            .getState()
-            .setSourcePriorities(
-              data as Parameters<SignalKStore['setSourcePriorities']>[0]
-            )
-        })
+        useStore
+          .getState()
+          .setSourcePriorities(
+            data as Parameters<SignalKStore['setSourcePriorities']>[0]
+          )
         break
       case 'RECEIVE_APPSTORE_LIST':
       case 'APP_STORE_CHANGED':
-        // Dynamic import avoids circular dependency with store
-        import('../store').then(({ useStore }) => {
-          useStore
-            .getState()
-            .setAppStore(data as Parameters<SignalKStore['setAppStore']>[0])
-        })
+        useStore
+          .getState()
+          .setAppStore(data as Parameters<SignalKStore['setAppStore']>[0])
         break
       default:
         console.debug('Unhandled server event:', eventType)


### PR DESCRIPTION
## Summary
- Extract `authFetch`, `fetchLoginStatus`, and `fetchAllData` from `actions.ts` into a new `dataFetching.ts` module
- This breaks the circular dependency between `WebSocketService.ts` and `actions.ts`, allowing static imports and eliminating Vite's "mixed dynamic/static imports" warnings
- Re-exports from `actions.ts` preserve backward compatibility for existing consumers

## Test plan
- [x] `npm run build:all` produces no "mixed dynamic/static imports" warnings
- [x] All existing imports from `actions.ts` continue to work

https://claude.ai/code/session_01RNKm53t3PF7PMuhZ1ToVYE