### PR TITLE
Raise Vite chunk size warning limit for admin UI

### DIFF
--- a/packages/server-admin-ui/vite.config.js
+++ b/packages/server-admin-ui/vite.config.js
@@ -165,7 +165,8 @@ export default defineConfig({
     sourcemap: true,
     target: 'es2023',
     assetsInlineLimit: 0, // Prevent inlining assets to allow server-side logo override
-    cssCodeSplit: false // Generate single CSS file to ensure it's always loaded
+    cssCodeSplit: false, // Generate single CSS file to ensure it's always loaded
+    chunkSizeWarningLimit: 2500
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Set `chunkSizeWarningLimit: 2500` in `vite.config.js`
- The bootstrap bundle (2,167 kB) is inherently large due to Bootstrap, React, and other dependencies in this single-page admin app

## Test plan
- [x] `npm run build:all` produces no chunk size warnings

https://claude.ai/code/session_01RNKm53t3PF7PMuhZ1ToVYE