### PR TITLE
Remove redundant workspace .npmrc in server-api

### DIFF
--- a/packages/server-api/.npmrc
+++ b/packages/server-api/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false


### PR DESCRIPTION
## Summary
- Delete `packages/server-api/.npmrc` which contained only `package-lock=false`
- npm ignores `.npmrc` files in workspace packages, making this file redundant and causing a warning during install

## Test plan
- [x] `npm install` produces no `.npmrc` workspace warning

https://claude.ai/code/session_01RNKm53t3PF7PMuhZ1ToVYE