### PR TITLE
Remove suboptimal converge option from AssemblyScript config

### DIFF
--- a/packages/assemblyscript-plugin-sdk/asconfig.json
+++ b/packages/assemblyscript-plugin-sdk/asconfig.json
@@ -5,7 +5,6 @@
       "sourceMap": false,
       "optimize": true,
       "shrinkLevel": 2,
-      "converge": true,
       "noAssert": true,
       "runtime": "stub",
       "use": "abort="


### PR DESCRIPTION
## Summary
- Remove `"converge": true` from `asconfig.json` release target
- The optimizer still runs via `"optimize": true` and `"shrinkLevel": 2`; the `converge` option triggers a "Last converge was suboptimal" warning because extra passes don't improve output

## Test plan
- [x] `npm run build:all` produces no "converge was suboptimal" warning

https://claude.ai/code/session_01RNKm53t3PF7PMuhZ1ToVYE