### PR TITLE
refactor(mdns): replace dnssd2 and mdns-js with @astronautlabs/mdns

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   ],
   "dependencies": {
     "@assemblyscript/loader": "^0.28.9",
+    "@astronautlabs/mdns": "^1.0.10",
     "@signalk/course-provider": "^1.0.0",
     "@signalk/n2k-signalk": ">=4.1.0-beta",
     "@signalk/nmea0183-signalk": "^3.0.0",
@@ -98,7 +99,6 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.5.2",
     "debug": "^4.3.3",
-    "dnssd2": "1.0.0",
     "errorhandler": "^1.3.0",
     "esm-resolve": "^1.0.11",
     "express": "^4.21.2",
@@ -113,7 +113,6 @@
     "lodash": "^4.17.21",
     "marked": "^17.0.5",
     "mathjs": "^12.4.0",
-    "mdns-js": "^1.0.3",
     "minimist": "^1.2.8",
     "moment": "^2.10.6",
     "morgan": "^1.5.0",

--- a/src/discovery.js
+++ b/src/discovery.js
@@ -18,7 +18,7 @@ import { createDebug } from './debug'
 const debug = createDebug('signalk-server:discovery')
 const canboatjs = require('@canboat/canboatjs')
 const dgram = require('dgram')
-const mdns = require('mdns-js')
+const { Browser } = require('@astronautlabs/mdns')
 const { networkInterfaces } = require('os')
 
 module.exports.runDiscovery = function (app) {
@@ -196,24 +196,16 @@ module.exports.runDiscovery = function (app) {
 
   function discoverSignalkWs(wsType) {
     try {
-      mdns.excludeInterface('0.0.0.0')
-      var browser = mdns.createBrowser(mdns.tcp('signalk-' + wsType))
+      const browser = new Browser('_signalk-' + wsType + '._tcp')
 
-      browser.on('ready', function onReady() {
-        try {
-          debug('looking for SignalK ' + wsType)
-          browser.discover()
-        } catch (err) {
-          debug('discoverSignalkWs:', err)
-        }
-      })
+      debug('looking for SignalK ' + wsType)
 
-      browser.on('update', function onUpdate(data) {
+      browser.on('serviceUp', function onServiceUp(data) {
         try {
           if (
             !isLocalIP(data.addresses[0]) &&
-            Array.isArray(data.type) &&
-            data.type[0].name === 'signalk-' + wsType &&
+            data.type &&
+            data.type.name === 'signalk-' + wsType &&
             !findWSProvider(data.addresses[0], wsType, data.host, data.port)
           ) {
             debug('discoverSignalkWs found data[' + wsType + ']:', data)
@@ -243,6 +235,12 @@ module.exports.runDiscovery = function (app) {
           debug('discoverSignalkWs:', err)
         }
       })
+
+      browser.on('error', (err) => {
+        debug('discoverSignalkWs:', err)
+      })
+
+      browser.start()
 
       setTimeout(() => {
         try {

--- a/src/mdns.js
+++ b/src/mdns.js
@@ -82,7 +82,10 @@ module.exports = function mdnsResponder(app) {
     txt: txtRecord
   }
 
-  const host = app.config.getExternalHostname()
+  const host = app.config
+    .getExternalHostname()
+    .replace(/\.$/, '')
+    .replace(/\.local$/i, '')
 
   if (host !== require('os').hostname()) {
     options.host = host

--- a/src/mdns.js
+++ b/src/mdns.js
@@ -19,21 +19,11 @@
 const _ = require('lodash')
 import { createDebug } from './debug'
 const debug = createDebug('signalk-server:mdns')
-const dnssd = require('dnssd2')
+const { Advertisement } = require('@astronautlabs/mdns')
 const ports = require('./ports')
 
 module.exports = function mdnsResponder(app) {
   const config = app.config
-
-  let mdns = dnssd
-
-  try {
-    mdns = require('mdns')
-    debug('using  mdns')
-  } catch (ex) {
-    debug(ex)
-    debug('mdns not found, using dnssd2')
-  }
 
   if (typeof config.settings.mdns !== 'undefined' && !config.settings.mdns) {
     debug('Mdns disabled by configuration')
@@ -59,8 +49,8 @@ module.exports = function mdnsResponder(app) {
   types.push({
     type:
       app.config.settings.ssl || app.config.isExternalSsl()
-        ? mdns.tcp('https')
-        : mdns.tcp('http'),
+        ? '_https._tcp'
+        : '_http._tcp',
     port: ports.getExternalPort(app)
   })
 
@@ -76,7 +66,7 @@ module.exports = function mdnsResponder(app) {
         service.name.charAt(0) === '_'
       ) {
         types.push({
-          type: mdns[service.type](service.name),
+          type: `${service.name}._${service.type}`,
           port: service.port
         })
       } else {
@@ -89,7 +79,6 @@ module.exports = function mdnsResponder(app) {
   }
 
   const options = {
-    txtRecord,
     txt: txtRecord
   }
 
@@ -113,9 +102,9 @@ module.exports = function mdnsResponder(app) {
         ':' +
         type.port
     )
-    const ad = new mdns.Advertisement(type.type, type.port, options)
+    const ad = new Advertisement(type.type, type.port, options)
     ad.on('error', (err) => {
-      console.log(type.type.name)
+      console.log(type.type)
       console.error(err)
     })
     ad.start()


### PR DESCRIPTION
Consolidates advertising and discovery onto a single pure-TypeScript mDNS/DNS-SD implementation with no native dependencies. The previous optional native `mdns` fallback is no longer needed.