### PR TITLE
chore(server-admin-ui): restore Vite 8 build

### DIFF
--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -66,6 +66,7 @@
     "lodash.set": "^4.3.2",
     "lodash.uniq": "^4.5.0",
     "mathjs": "^15.2.0",
+    "path-browserify": "^1.0.1",
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.0",
@@ -78,7 +79,7 @@
     "sass": "^1.81.0",
     "simple-line-icons": "^2.5.5",
     "typescript": "^5.7.2",
-    "vite": "8.0.8",
+    "vite": "^8.0.9",
     "vitest": "^4.1.2"
   },
   "scripts": {

--- a/packages/server-admin-ui/vite.config.ts
+++ b/packages/server-admin-ui/vite.config.ts
@@ -2,7 +2,6 @@
 import { defineConfig } from 'vite'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import babel from '@rolldown/plugin-babel'
-import { federation } from '@module-federation/vite'
 
 import '@signalk/server-admin-ui-dependencies'
 
@@ -71,8 +70,6 @@ function stripSvgFonts() {
   }
 }
 
-const isTest = process.env.VITEST === 'true'
-
 export default defineConfig({
   base: './',
   publicDir: 'public_src',
@@ -82,29 +79,7 @@ export default defineConfig({
     react(),
     babel({
       presets: [reactCompilerPreset()]
-    }),
-    // Module Federation runtime injects http: imports incompatible with
-    // Node.js ESM loader, so skip it during vitest runs.
-    ...(!isTest
-      ? [
-          federation({
-            name: 'adminUI',
-            filename: 'remoteEntry.js',
-            remotes: {},
-            dts: false,
-            shared: {
-              react: {
-                singleton: true,
-                requiredVersion: '^19.0.0'
-              },
-              'react-dom': {
-                singleton: true,
-                requiredVersion: '^19.0.0'
-              }
-            }
-          })
-        ]
-      : [])
+    })
   ],
   css: {
     preprocessorOptions: {
@@ -159,7 +134,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      path: false,
+      path: 'path-browserify',
       events: 'events',
       buffer: 'buffer'
     }


### PR DESCRIPTION
Remove the admin UI's host-side federation plugin wiring so the host build no longer rewrites its own React imports into async share-loader modules that fail under the current Vite/Rolldown production build.

Replace the unsupported path: false alias with path-browserify so the Vite 8 build config remains browser-compatible and valid.