### PR TITLE
Fix multi-arch manifest creation with run_id tagging

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -129,7 +129,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${{ matrix.arch }}-${{ matrix.os_label }}-${{ matrix.node }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${{ matrix.arch }}-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.run_id }}
           build-args: |
             NODE=${{ matrix.node }}
 
@@ -156,8 +156,8 @@ jobs:
           tags: |
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:latest-${{ matrix.os_label }}-${{ matrix.node }}
           sources: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:amd-${{ matrix.os_label }}-${{ matrix.node }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:arm-${{ matrix.os_label }}-${{ matrix.node }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:amd-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.run_id }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:arm-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.run_id }}
 
   copy-to-dockerhub:
     name: Copy ${{ matrix.os_label }} node-${{ matrix.node }} to Docker Hub
@@ -205,5 +205,5 @@ jobs:
           packages: signalk-server-base
           delete-untagged: true
           delete-tags: |
-            amd-*,arm-*
+            *-${{ github.run_id }}
           token: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -125,7 +125,20 @@ jobs:
           ' .github/build-matrix.json)
 
           # Variant matrix: one row per variant (used by manifest + copy jobs).
-          variant_matrix=$(echo "$variants" | jq -c '[ .[] | {os_label, node, suffix} ]')
+          # archs is derived from build_matrix so the manifest sources reflect
+          # the architectures actually built (respecting exclude_archs).
+          variant_matrix=$(jq -cn \
+            --argjson variants "$variants" \
+            --argjson build_matrix "$build_matrix" '
+            [ $variants[] as $v |
+              ($v + {
+                archs: [ $build_matrix[]
+                  | select(.os_label == $v.os_label and .node == $v.node)
+                  | .arch ]
+              })
+              | {os_label, node, suffix, archs}
+            ]
+          ')
 
           count=$(echo "$variants" | jq 'length')
           if [[ "$count" -gt 0 ]]; then
@@ -205,14 +218,31 @@ jobs:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
+      - name: Compute manifest sources
+        id: sources
+        env:
+          ARCHS_JSON: ${{ toJSON(matrix.archs) }}
+          SRC_PREFIX: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}
+          OS: ${{ matrix.os_label }}
+          NODE: ${{ matrix.node }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          srcs=$(jq -r \
+            --arg p "$SRC_PREFIX" --arg o "$OS" --arg n "$NODE" --arg r "$RUN_ID" \
+            '.[] | "\($p):\(.)-\($o)-\($n)-\($r)"' <<<"$ARCHS_JSON")
+          {
+            echo 'value<<EOF'
+            echo "$srcs"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Create and push multi-arch manifest to GHCR
         uses: int128/docker-manifest-create-action@v2
         with:
           tags: |
             ${{ steps.docker_meta.outputs.tags }}
           sources: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:amd-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.run_id }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:arm-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.run_id }}
+            ${{ steps.sources.outputs.value }}
       - name: Save tags to file
         run: |
           mkdir -p /tmp/tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
   prepare:
     name: Prepare matrices
     needs: [build_and_publish]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     outputs:
       build_matrix: ${{ steps.matrix.outputs.build_matrix }}


### PR DESCRIPTION
## Summary
This PR fixes the multi-arch Docker manifest creation process by introducing run_id-based image tagging and dynamically computing manifest sources based on actually-built architectures.

## Key Changes

- **Dynamic architecture tracking**: Modified `build-docker.yml` to derive the `archs` field in the variant matrix from the actual `build_matrix`, ensuring manifest sources only reference architectures that were actually built (respecting `exclude_archs` configurations).

- **Run ID-based image tagging**: Updated both `build-base-image.yml` and `build-docker.yml` to append `github.run_id` to image tags, preventing tag collisions and enabling proper cleanup of temporary build images.

- **Computed manifest sources**: Replaced hardcoded `amd` and `arm` architecture references with a dynamically computed `sources` output that generates the correct image references based on the variant's actual architectures.

- **Improved cleanup**: Changed the GHCR cleanup pattern from `amd-*,arm-*` to `*-${{ github.run_id }}` to specifically target and remove temporary build images from the current workflow run.

- **Release workflow guard**: Added a condition to the `prepare` job in `release.yml` to only run on tag pushes (`startsWith(github.ref, 'refs/tags/')`), preventing unnecessary execution on non-release workflows.

## Implementation Details

The variant matrix now includes architecture information computed from the build matrix:
```
archs: [ $build_matrix[] | select(.os_label == $v.os_label and .node == $v.node) | .arch ]
```

This ensures that if certain architectures are excluded via `exclude_archs`, the manifest will only reference the architectures that were actually built, preventing manifest creation failures due to missing image references.