### PR TITLE
Add stable admin UI asset resolution endpoint for plugins

### DIFF
--- a/packages/server-admin-ui/vite.config.ts
+++ b/packages/server-admin-ui/vite.config.ts
@@ -130,7 +130,8 @@ export default defineConfig({
     sourcemap: true,
     target: 'es2023',
     assetsInlineLimit: 0, // Prevent inlining assets to allow server-side logo override
-    cssCodeSplit: false // Generate single CSS file to ensure it's always loaded
+    cssCodeSplit: false, // Generate single CSS file to ensure it's always loaded
+    manifest: true // Emit .vite/manifest.json so plugins can resolve hashed asset URLs
   },
   resolve: {
     alias: {

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -302,6 +302,23 @@ module.exports = function (
     serveIndexWithAddonScripts(path.join(adminUiPath, 'index.html'), res)
   })
 
+  // Stable endpoint for plugins/webapps to resolve current admin UI asset URLs
+  // without depending on Vite manifest internals.
+  app.get('/admin/assets.json', (_req: Request, res: Response) => {
+    const manifestPath = path.join(adminUiPath, '.vite', 'manifest.json')
+    fs.readFile(manifestPath, 'utf8', (err, content) => {
+      if (err) {
+        res.status(404).json({ error: 'manifest not available' })
+        return
+      }
+      const entry = JSON.parse(content)['index.html']
+      res.json({
+        css: (entry.css || []).map((f: string) => `/admin/${f}`),
+        js: [`/admin/${entry.file}`]
+      })
+    })
+  })
+
   app.use('/admin', express.static(adminUiPath))
 
   app.get('/', (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
This PR adds a stable `/admin/assets.json` endpoint that allows plugins and webapps to resolve current admin UI asset URLs without depending on Vite's internal manifest structure. This enables proper asset loading even when filenames are hashed during the build process.

## Key Changes
- **New endpoint `/admin/assets.json`**: Reads the Vite manifest and exposes CSS and JS asset URLs in a stable, plugin-friendly format
  - Returns CSS files as an array under the `css` key
  - Returns the main JS entry point under the `js` key
  - All paths are prefixed with `/admin/` for proper routing
  - Returns a 404 error if the manifest is unavailable
- **Enable Vite manifest generation**: Updated `vite.config.ts` to emit `.vite/manifest.json` by setting `manifest: true` in the build configuration

## Implementation Details
- The endpoint parses the Vite manifest and extracts the `index.html` entry point
- Asset paths are transformed from relative manifest paths to absolute `/admin/` prefixed URLs
- This approach decouples plugins from Vite's internal build artifacts while maintaining compatibility with hashed asset filenames

https://claude.ai/code/session_011XLyykrxASkTbZ5pT9EpiR