### PR TITLE
Implement React sharing via import map for ESM plugins

### DIFF
--- a/docs/develop/webapps.md
+++ b/docs/develop/webapps.md
@@ -174,57 +174,51 @@ The server loads these via a classic `<script>` tag which places the container o
 
 ### Vite / ESM bundlers
 
-The server also supports ESM containers produced by Vite, Rollup, esbuild, or any bundler that outputs standard `export { init, get }`. To use an ESM container:
+The server also supports ESM containers produced by Vite, Rollup, esbuild, or any bundler that outputs `export { init, get }`. Set `"type": "module"` in the plugin's `package.json` and the server emits `<script type="module">` for the container; the Admin UI loads it via dynamic `import()` when the expected name is not present on `window`.
 
-1. Set `"type": "module"` in your plugin's `package.json`. The server uses this to emit `<script type="module">` instead of a classic `<script>` tag.
-2. Configure your bundler to produce a Module Federation container as ESM. For example with `@module-federation/vite`:
+If the plugin's server-side code remains CommonJS (`module.exports`), give `"main"` a `.cjs` extension so Node.js still loads it as CommonJS under the module-typed package.
+
+### React Version Compatibility
+
+The Admin UI uses **React 19** with functional components and hooks. Your plugin must use the host's React instance — bundling a second copy yields `Cannot read properties of null (reading 'useState')` when the plugin's hooks read a dispatcher that the host activated on its React, not the plugin's.
+
+#### Sharing React with the host
+
+**ESM bundlers (Vite, Rollup, esbuild)** — the Admin UI's `index.html` ships a browser import map that points `react`, `react-dom`, `react-dom/client`, and `react/jsx-runtime` at proxy modules served by the host. Mark those specifiers as external in your bundle and the browser resolves `import 'react'` to the host's React at runtime:
 
 ```javascript
 // vite.config.js
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { federation } from '@module-federation/vite'
 
 export default defineConfig({
-  plugins: [
-    react(),
-    federation({
-      name: 'my-plugin',
-      filename: 'remoteEntry.js',
-      exposes: {
-        './PluginConfigurationPanel': './src/PluginConfigurationPanel.tsx'
-      },
-      shared: {
-        react: { singleton: true, requiredVersion: false },
-        'react-dom': { singleton: true, requiredVersion: false }
-      }
-    })
-  ],
-  define: {
-    'process.env.NODE_ENV': JSON.stringify('production')
-  },
+  plugins: [react()],
+  define: { 'process.env.NODE_ENV': JSON.stringify('production') },
   build: {
     outDir: 'public',
-    emptyOutDir: false
+    emptyOutDir: false,
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime'],
+      output: { format: 'es', entryFileNames: 'remoteEntry.js' }
+    }
   }
 })
 ```
 
-The `process.env.NODE_ENV` define is required because some shared dependencies reference `process.env` which is not available in the browser.
+No `resolve.alias`, no shim files, no Module Federation `shared` declaration — the plugin's `import { useState } from 'react'` resolves natively via the import map to the host's React instance, so hooks share the host's dispatcher.
 
-If your plugin's server-side code uses CommonJS (`module.exports`), set `"main"` to a `.cjs` file so Node.js treats it as CommonJS despite the `"type": "module"` in `package.json`.
+The `process.env.NODE_ENV` define is required because some dependencies reference `process.env` which is not available in the browser.
 
-The Admin UI detects ESM containers automatically via dynamic `import()` when the expected container is not present on `window`.
+**Webpack (`var` library)** — webpack-MF's runtime hooks into the host's share scope automatically when you declare React as a singleton:
 
-### React Version Compatibility
+```javascript
+shared: {
+  react: { singleton: true, requiredVersion: '^19' },
+  'react-dom': { singleton: true, requiredVersion: '^19' }
+}
+```
 
-The Admin UI uses **React 19** with shared dependencies via Module Federation. Your embedded webapp should:
-
-1. **Share React as a singleton** - Configure Module Federation to use the host's React instance with `requiredVersion: false`. See [vite.config.js](https://github.com/SignalK/signalk-server/blob/master/packages/server-admin-ui/vite.config.js) for the current configuration.
-
-2. **Use functional components** - The Admin UI is built with functional components and React hooks. While class components still work, functional components are recommended for consistency.
-
-See the Calibration plugin for an example. It is probably easier to start with an existing plugin and modify it to suit your needs. Don't forget to change the module id and name in package.json!
+See the Calibration plugin for an existing webpack-based example to start from. It is probably easier to start with an existing plugin and modify it to suit your needs. Don't forget to change the module id and name in package.json!
 
 ## WebApp / Component and Admin UI / Server interfaces
 

--- a/packages/server-admin-ui/index.html
+++ b/packages/server-admin-ui/index.html
@@ -9,6 +9,17 @@
     />
     <meta name="description" content="Signal K Node Server" />
 
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "./host-modules/react.js",
+          "react-dom": "./host-modules/react-dom.js",
+          "react-dom/client": "./host-modules/react-dom-client.js",
+          "react/jsx-runtime": "./host-modules/react-jsx-runtime.js"
+        }
+      }
+    </script>
+
     %ADDONSCRIPTS%
 
     <link rel="shortcut icon" href="img/favicon.ico" />

--- a/packages/server-admin-ui/public_src/host-modules/react-dom-client.js
+++ b/packages/server-admin-ui/public_src/host-modules/react-dom-client.js
@@ -1,0 +1,11 @@
+const h = globalThis.__SK_REACT_DOM_CLIENT__
+if (!h) {
+  throw new Error(
+    'SignalK host react-dom/client not found on globalThis.__SK_REACT_DOM_CLIENT__. ' +
+      'Is this module being loaded outside the admin UI?'
+  )
+}
+
+export default h.default ?? h
+export const createRoot = h.createRoot
+export const hydrateRoot = h.hydrateRoot

--- a/packages/server-admin-ui/public_src/host-modules/react-dom.js
+++ b/packages/server-admin-ui/public_src/host-modules/react-dom.js
@@ -1,0 +1,26 @@
+const h = globalThis.__SK_REACT_DOM__
+if (!h) {
+  throw new Error(
+    'SignalK host ReactDOM not found on globalThis.__SK_REACT_DOM__. ' +
+      'Is this module being loaded outside the admin UI?'
+  )
+}
+
+export default h.default ?? h
+export const version = h.version
+
+export const createPortal = h.createPortal
+export const flushSync = h.flushSync
+
+export const preconnect = h.preconnect
+export const prefetchDNS = h.prefetchDNS
+export const preinit = h.preinit
+export const preinitModule = h.preinitModule
+export const preload = h.preload
+export const preloadModule = h.preloadModule
+export const requestFormReset = h.requestFormReset
+
+export const useFormStatus = h.useFormStatus
+
+export const findDOMNode = h.findDOMNode
+export const unstable_batchedUpdates = h.unstable_batchedUpdates

--- a/packages/server-admin-ui/public_src/host-modules/react-jsx-runtime.js
+++ b/packages/server-admin-ui/public_src/host-modules/react-jsx-runtime.js
@@ -1,0 +1,13 @@
+const h = globalThis.__SK_REACT_JSX_RUNTIME__
+if (!h) {
+  throw new Error(
+    'SignalK host react/jsx-runtime not found on globalThis.__SK_REACT_JSX_RUNTIME__. ' +
+      'Is this module being loaded outside the admin UI?'
+  )
+}
+
+export default h.default ?? h
+export const Fragment = h.Fragment
+export const jsx = h.jsx
+export const jsxs = h.jsxs
+export const jsxDEV = h.jsxDEV

--- a/packages/server-admin-ui/public_src/host-modules/react.js
+++ b/packages/server-admin-ui/public_src/host-modules/react.js
@@ -1,0 +1,49 @@
+// Served verbatim (lives in publicDir, not Vite-processed). Resolves the
+// admin UI's import map entry for `react` to the host's React instance,
+// which bootstrap.tsx assigns to window.__SK_REACT__ before render.
+const h = globalThis.__SK_REACT__
+if (!h) {
+  throw new Error(
+    'SignalK host React not found on globalThis.__SK_REACT__. ' +
+      'Is this module being loaded outside the admin UI?'
+  )
+}
+
+export default h.default ?? h
+export const version = h.version
+
+export const Children = h.Children
+export const Fragment = h.Fragment
+export const Profiler = h.Profiler
+export const StrictMode = h.StrictMode
+export const Suspense = h.Suspense
+
+export const cloneElement = h.cloneElement
+export const createContext = h.createContext
+export const createElement = h.createElement
+export const createRef = h.createRef
+export const forwardRef = h.forwardRef
+export const isValidElement = h.isValidElement
+export const lazy = h.lazy
+export const memo = h.memo
+export const startTransition = h.startTransition
+export const act = h.act
+export const use = h.use
+
+export const useActionState = h.useActionState
+export const useCallback = h.useCallback
+export const useContext = h.useContext
+export const useDebugValue = h.useDebugValue
+export const useDeferredValue = h.useDeferredValue
+export const useEffect = h.useEffect
+export const useId = h.useId
+export const useImperativeHandle = h.useImperativeHandle
+export const useInsertionEffect = h.useInsertionEffect
+export const useLayoutEffect = h.useLayoutEffect
+export const useMemo = h.useMemo
+export const useOptimistic = h.useOptimistic
+export const useReducer = h.useReducer
+export const useRef = h.useRef
+export const useState = h.useState
+export const useSyncExternalStore = h.useSyncExternalStore
+export const useTransition = h.useTransition

--- a/packages/server-admin-ui/src/bootstrap.tsx
+++ b/packages/server-admin-ui/src/bootstrap.tsx
@@ -1,3 +1,7 @@
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import * as ReactDOMClient from 'react-dom/client'
+import * as ReactJSXRuntime from 'react/jsx-runtime'
 import { createRoot } from 'react-dom/client'
 import { HashRouter, Routes, Route } from 'react-router-dom'
 
@@ -8,7 +12,24 @@ import '../scss/core/_dropdown-menu-right.scss'
 import Full from './containers/Full/Full'
 import { WebSocketProvider } from './contexts/WebSocketContext'
 
+declare global {
+  interface Window {
+    __SK_REACT__?: typeof React
+    __SK_REACT_DOM__?: typeof ReactDOM
+    __SK_REACT_DOM_CLIENT__?: typeof ReactDOMClient
+    __SK_REACT_JSX_RUNTIME__?: typeof ReactJSXRuntime
+  }
+}
+
 window.serverRoutesPrefix = '/skServer'
+
+// Carrier for the import map's host-modules/*.js proxies. ESM plugins
+// resolve `import 'react'` (etc.) through the admin UI's import map to
+// these globals, sharing the host's React instance and dispatcher.
+window.__SK_REACT__ = React
+window.__SK_REACT_DOM__ = ReactDOM
+window.__SK_REACT_DOM_CLIENT__ = ReactDOMClient
+window.__SK_REACT_JSX_RUNTIME__ = ReactJSXRuntime
 
 const container = document.getElementById('root')!
 const root = createRoot(container)


### PR DESCRIPTION
## Summary

This PR refactors how the Admin UI shares React with embedded ESM plugins, replacing Module Federation with a browser import map approach. This simplifies plugin configuration and ensures plugins use the host's React instance without bundling their own copy.

## Key Changes

- **Import map-based React sharing**: Added `<script type="importmap">` to `index.html` that redirects `react`, `react-dom`, `react-dom/client`, and `react/jsx-runtime` imports to proxy modules served by the host
- **Host module proxies**: Created four new proxy modules (`react.js`, `react-dom.js`, `react-dom-client.js`, `react-jsx-runtime.js`) in `public_src/host-modules/` that expose the host's React instance via globals (`__SK_REACT__`, `__SK_REACT_DOM__`, etc.)
- **Bootstrap setup**: Modified `bootstrap.tsx` to assign React modules to window globals before rendering, making them available to the import map proxies
- **Simplified plugin guidance**: Updated `webapps.md` documentation to remove Module Federation configuration and provide clearer ESM bundler setup instructions using only `external` and `rollupOptions` in Vite config
- **Webpack fallback**: Retained webpack-based singleton configuration guidance for plugins still using webpack Module Federation

## Implementation Details

- The import map intercepts all `import 'react'` statements in ESM plugins and routes them to the proxy modules
- Proxy modules validate that globals are set and re-export the host's React instance, ensuring all plugins share the same React dispatcher
- This eliminates the "Cannot read properties of null (reading 'useState')" error that occurred when plugins bundled their own React
- The approach is simpler than Module Federation and requires no special bundler plugins for ESM-based plugins
- CommonJS server-side code continues to work via `.cjs` file extensions in `package.json`'s `"main"` field