### PR TITLE
Generate Docker workflow_dispatch inputs from build-matrix.json

### DIFF
--- a/.github/scripts/sync-dispatch-inputs.mjs
+++ b/.github/scripts/sync-dispatch-inputs.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Regenerate the workflow_dispatch.inputs block of each workflow YAML from
+// .github/build-matrix.json. The block to replace is delimited by BEGIN/END
+// marker comments — see MARKERS below. The indent of the BEGIN line and the
+// file's existing line ending (LF or CRLF) are preserved.
+//
+// Usage:
+//   node .github/scripts/sync-dispatch-inputs.mjs            regenerate in place
+//   node .github/scripts/sync-dispatch-inputs.mjs --check    exit 1 if any drift
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { argv, exit } from 'node:process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..', '..')
+const matrixPath = resolve(repoRoot, '.github', 'build-matrix.json')
+
+const WORKFLOWS = [
+  '.github/workflows/build-base-image.yml',
+  '.github/workflows/build-docker.yml'
+]
+
+const BEGIN =
+  '# >>> BEGIN auto-generated dispatch inputs (from build-matrix.json — run .github/scripts/sync-dispatch-inputs.mjs to update)'
+const END = '# <<< END auto-generated dispatch inputs'
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function titleCase(s) {
+  return s[0].toUpperCase() + s.slice(1)
+}
+
+function osDisplay(os) {
+  // { family: 'ubuntu', id: '24.04' } -> 'Ubuntu 24.04'
+  // { family: 'alpine', id: 'alpine' } -> 'Alpine'
+  const family = titleCase(os.family)
+  return os.id === os.family ? family : `${family} ${os.id}`
+}
+
+function nodeDisplay(os, node) {
+  return os.family === 'ubuntu' ? `Node ${node.id}.x` : `Node ${node.id}`
+}
+
+function keyFor(os, node) {
+  // { family: 'ubuntu', id: '24.04' } + node '24' -> 'ubuntu_24_04_node_24'
+  // { family: 'alpine', id: 'alpine' } + node '24' -> 'alpine_node_24'
+  const idPart = os.id.replace(/[-.]/g, '_')
+  const prefix = os.family === os.id ? '' : `${os.family}_`
+  return `${prefix}${idPart}_node_${node.id}`
+}
+
+function buildBlock(matrix, indent) {
+  const lines = []
+  for (const os of matrix.os_variants) {
+    for (const node of matrix.node_versions) {
+      const key = keyFor(os, node)
+      const desc = `${osDisplay(os)} + ${nodeDisplay(os, node)}`
+      const def = os.default_enabled && node.default_enabled ? 'true' : 'false'
+      lines.push(`${indent}${key}:`)
+      lines.push(`${indent}  description: '${desc}'`)
+      lines.push(`${indent}  type: boolean`)
+      lines.push(`${indent}  default: ${def}`)
+    }
+  }
+  return lines
+}
+
+const matrix = JSON.parse(readFileSync(matrixPath, 'utf8'))
+const check = argv.includes('--check')
+let drift = false
+let missingMarkers = false
+
+const beginRe = new RegExp(
+  `^([ \\t]*)${escapeRegExp(BEGIN)}[^\\r\\n]*(\\r?\\n)`,
+  'm'
+)
+const endRe = new RegExp(`^[ \\t]*${escapeRegExp(END)}`, 'm')
+
+for (const rel of WORKFLOWS) {
+  const path = resolve(repoRoot, rel)
+  const original = readFileSync(path, 'utf8')
+
+  const beginMatch = original.match(beginRe)
+  const endMatch = original.match(endRe)
+
+  if (!beginMatch || !endMatch || endMatch.index <= beginMatch.index) {
+    console.error(`! ${rel}: BEGIN/END markers missing or malformed.`)
+    console.error(
+      `  Expected, on their own lines, inside 'workflow_dispatch.inputs:':`
+    )
+    console.error(`    ${BEGIN}`)
+    console.error(`    ${END}`)
+    missingMarkers = true
+    continue
+  }
+
+  const indent = beginMatch[1]
+  const eol = beginMatch[2]
+  const beginEnd = beginMatch.index + beginMatch[0].length
+  const endStart = endMatch.index
+
+  const block = buildBlock(matrix, indent).join(eol) + eol
+  const updated = original.slice(0, beginEnd) + block + original.slice(endStart)
+
+  if (updated === original) {
+    console.log(`= ${rel}: up to date`)
+    continue
+  }
+
+  if (check) {
+    console.error(
+      `x ${rel}: out of sync with build-matrix.json — run 'node .github/scripts/sync-dispatch-inputs.mjs'`
+    )
+    drift = true
+  } else {
+    writeFileSync(path, updated)
+    console.log(`> ${rel}: regenerated`)
+  }
+}
+
+if (missingMarkers) exit(2)
+if (check && drift) exit(1)

--- a/.github/scripts/sync-dispatch-inputs.mjs
+++ b/.github/scripts/sync-dispatch-inputs.mjs
@@ -19,7 +19,8 @@ const matrixPath = resolve(repoRoot, '.github', 'build-matrix.json')
 
 const WORKFLOWS = [
   '.github/workflows/build-base-image.yml',
-  '.github/workflows/build-docker.yml'
+  '.github/workflows/build-docker.yml',
+  '.github/workflows/release.yml'
 ]
 
 const BEGIN =

--- a/.github/scripts/sync-dispatch-inputs.mjs
+++ b/.github/scripts/sync-dispatch-inputs.mjs
@@ -47,8 +47,10 @@ function nodeDisplay(os, node) {
 }
 
 function keyFor(os, node) {
-  // { family: 'ubuntu', id: '24.04' } + node '24' -> 'ubuntu_24_04_node_24'
-  // { family: 'alpine', id: 'alpine' } + node '24' -> 'alpine_node_24'
+  // Must match the prepare-job jq lookup and start with a letter (GH Actions
+  // input-name rule). Family is prefixed when distinct from id so '24.04' -
+  // which would otherwise produce an invalid '24_04_...' identifier - becomes
+  // 'ubuntu_24_04_node_24'. 'alpine' (family == id) stays 'alpine_node_24'.
   const idPart = os.id.replace(/[-.]/g, '_')
   const prefix = os.family === os.id ? '' : `${os.family}_`
   return `${prefix}${idPart}_node_${node.id}`

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -53,7 +53,7 @@ jobs:
             (if ($enabled | type) == "object" then $enabled else {} end) as $en
             | .os_variants as $os | .node_versions as $nodes
             | [ $os[] as $o | $nodes[] as $n |
-                (($o.id | gsub("[-.]"; "_")) + "_node_" + $n.id) as $key |
+                ((if $o.family == $o.id then "" else "\($o.family)_" end) + ($o.id | gsub("[-.]"; "_")) + "_node_" + $n.id) as $key |
                 {
                   enabled: ($en[$key] // (if ($o.default_enabled and $n.default_enabled) then "true" else "false" end)),
                   family:     $o.family,

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -4,11 +4,12 @@ on:
   schedule:
     - cron: '0 0 * * 1'
   # Per-(OS x Node) checkboxes. The catalogue of available combinations
-  # lives in .github/build-matrix.json - add a row there, then add a
-  # matching input below. Input names must be: <os_id_with_-_and_._mapped_to__>_node_<node_id>.
+  # lives in .github/build-matrix.json - the inputs below are generated from
+  # it by .github/scripts/sync-dispatch-inputs.mjs (CI keeps them in sync).
   # Scheduled runs ignore inputs and use default_enabled from the JSON.
   workflow_dispatch:
     inputs:
+      # >>> BEGIN auto-generated dispatch inputs (from build-matrix.json — run .github/scripts/sync-dispatch-inputs.mjs to update)
       ubuntu_24_04_node_24:
         description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
@@ -17,6 +18,7 @@ on:
         description: 'Alpine + Node 24'
         type: boolean
         default: true
+      # <<< END auto-generated dispatch inputs
 
 env:
   GHCR_REGISTRY: ghcr.io

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -93,7 +93,7 @@ jobs:
             (if ($enabled | type) == "object" then $enabled else {} end) as $en
             | .os_variants as $os | .node_versions as $nodes
             | [ $os[] as $o | $nodes[] as $n |
-                (($o.id | gsub("[-.]"; "_")) + "_node_" + $n.id) as $key |
+                ((if $o.family == $o.id then "" else "\($o.family)_" end) + ($o.id | gsub("[-.]"; "_")) + "_node_" + $n.id) as $key |
                 {
                   enabled: ($en[$key] // (if ($o.default_enabled and $n.default_enabled) then "true" else "false" end)),
                   family:    $o.family,

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -13,11 +13,12 @@ on:
       - '*'
       - '!v*'
   # Per-(OS x Node) checkboxes. The catalogue of available combinations
-  # lives in .github/build-matrix.json - add a row there, then add a
-  # matching input below. Input names must be: <os_id_with_-_and_._mapped_to__>_node_<node_id>.
+  # lives in .github/build-matrix.json - the inputs below are generated from
+  # it by .github/scripts/sync-dispatch-inputs.mjs (CI keeps them in sync).
   # Push / tag runs ignore inputs and use default_enabled from the JSON.
   workflow_dispatch:
     inputs:
+      # >>> BEGIN auto-generated dispatch inputs (from build-matrix.json — run .github/scripts/sync-dispatch-inputs.mjs to update)
       ubuntu_24_04_node_24:
         description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
@@ -26,6 +27,7 @@ on:
         description: 'Alpine + Node 24'
         type: boolean
         default: true
+      # <<< END auto-generated dispatch inputs
 
 env:
   GHCR_REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,22 @@ on:
   push:
     tags:
       - 'v*'
+  # Per-(OS x Node) checkboxes. The catalogue of available combinations
+  # lives in .github/build-matrix.json - the inputs below are generated from
+  # it by .github/scripts/sync-dispatch-inputs.mjs (CI keeps them in sync).
+  # Tag-triggered runs ignore inputs and use default_enabled from the JSON.
   workflow_dispatch:
+    inputs:
+      # >>> BEGIN auto-generated dispatch inputs (from build-matrix.json — run .github/scripts/sync-dispatch-inputs.mjs to update)
+      ubuntu_24_04_node_24:
+        description: 'Ubuntu 24.04 + Node 24.x'
+        type: boolean
+        default: true
+      alpine_node_24:
+        description: 'Alpine + Node 24'
+        type: boolean
+        default: true
+      # <<< END auto-generated dispatch inputs
 
 permissions:
   id-token: write # Required for OIDC

--- a/.github/workflows/sync-dispatch-inputs.yml
+++ b/.github/workflows/sync-dispatch-inputs.yml
@@ -21,6 +21,7 @@ on:
       - '.github/scripts/sync-dispatch-inputs.mjs'
       - '.github/workflows/build-base-image.yml'
       - '.github/workflows/build-docker.yml'
+      - '.github/workflows/release.yml'
       - '.github/workflows/sync-dispatch-inputs.yml'
   workflow_dispatch:
 

--- a/.github/workflows/sync-dispatch-inputs.yml
+++ b/.github/workflows/sync-dispatch-inputs.yml
@@ -1,0 +1,66 @@
+name: Sync workflow_dispatch inputs from build-matrix.json
+
+# Keeps the per-(OS x Node) checkboxes in the build workflows in lockstep with
+# .github/build-matrix.json so the JSON is the single source of truth.
+#
+#   PR          -> runs in --check mode and fails if the generated YAML differs.
+#                  Author must run the generator locally and push the result.
+#   push master -> regenerates the YAML and auto-commits with [skip ci] if it
+#                  drifted (e.g. after merging a PR that only edited the JSON).
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.github/build-matrix.json'
+      - '.github/scripts/sync-dispatch-inputs.mjs'
+      - '.github/workflows/sync-dispatch-inputs.yml'
+  pull_request:
+    paths:
+      - '.github/build-matrix.json'
+      - '.github/scripts/sync-dispatch-inputs.mjs'
+      - '.github/workflows/build-base-image.yml'
+      - '.github/workflows/build-docker.yml'
+      - '.github/workflows/sync-dispatch-inputs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: github.repository == 'SignalK/signalk-server'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Check (PR) or regenerate (push)
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            node .github/scripts/sync-dispatch-inputs.mjs --check
+          else
+            node .github/scripts/sync-dispatch-inputs.mjs
+          fi
+
+      - name: Commit regenerated YAML
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .github/workflows; then
+            echo "No drift — nothing to commit."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/workflows/*.yml
+          git commit -m "chore: sync workflow_dispatch inputs from build-matrix.json [skip ci]"
+          git push


### PR DESCRIPTION
## Why

`.github/build-matrix.json` is the source of truth for which OS × Node combos the Docker workflows build, but the per-(OS × Node) `workflow_dispatch.inputs` in `build-base-image.yml`, `build-docker.yml` and `release.yml` were maintained by hand — easy to forget and drift after editing the JSON.

A latent bug was also lurking: the prepare-job jq derived its lookup key from `os.id` alone (e.g. `24_04_node_24`), while the dispatch inputs are family-prefixed (`ubuntu_24_04_node_24`) because GH Actions input names must start with a letter. The mismatch silently made all dispatch toggles fall back to `default_enabled`.

## How

- `.github/scripts/sync-dispatch-inputs.mjs` regenerates the `workflow_dispatch.inputs` block of each Docker workflow between `BEGIN/END` markers from `build-matrix.json`. Supports `--check` for drift detection.
- `.github/workflows/sync-dispatch-inputs.yml` runs `--check` on PRs (fails on drift) and regenerates + auto-commits `[skip ci]` on push to `master`.
- Prepare-job jq in `build-base-image.yml` and `build-docker.yml` now builds the lookup key as `<family>_<id>_node_<node_id>` (family elided when `family == id`), so dispatch checkboxes are actually honored.

Tag-, push- and schedule-triggered runs continue to fall back to `default_enabled` and are unaffected by the fix. `release.yml`'s dispatch inputs are included for single-source-of-truth consistency but remain cosmetic — its prepare job is tag-gated.

https://claude.ai/code/session_01Tk2LVNF1yHz3SKdCo4EtxF