### PR TITLE
Apply PR #82 review feedback to matrix-driven Docker workflows

### DIFF
--- a/.github/build-matrix.json
+++ b/.github/build-matrix.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Single source of truth for the OS x Node x Arch combinations the Docker workflows can build. To add a new OS: append to os_variants and add matching workflow_dispatch inputs (one per node) to build-base-image.yml, build-docker.yml and release.yml. Input names must be: <os_id_with_-_and_._mapped_to__>_node_<node_id>. Scheduled / push / tag runs ignore inputs and use default_enabled from the JSON. To add a new Node major: append to node_versions and add matching workflow_dispatch inputs on every os_variants row. To add a new build runner / arch: append to architectures (id is the SK-side arch suffix in tags - keep stable to preserve existing GHCR tags). Per-node platform tweaks live on node_versions: extra_platforms[arch.id] is appended to the arch's base platform; exclude_archs (optional) lists arch ids that should not be built for that node. For the ubuntu family the node label in image tags is rendered as '<node>.x'; for other families it is '<node>'.",
+  "_comment": "Source of truth for the OS x Node x Arch combinations the Docker workflows build. See .github/docs/build-matrix.md for field definitions, naming conventions, and how to add new rows.",
   "architectures": [
     { "id": "amd", "vm": "ubuntu-latest", "platform": "linux/amd64" },
     { "id": "arm", "vm": "ubuntu-24.04-arm", "platform": "linux/arm64" }

--- a/.github/docs/build-matrix.md
+++ b/.github/docs/build-matrix.md
@@ -1,0 +1,36 @@
+# Docker build matrix
+
+`.github/build-matrix.json` is the single source of truth for the OS × Node × Arch combinations the Docker workflows build. The three Docker workflows — `build-base-image.yml`, `build-docker.yml` and `release.yml` — read it in their `prepare` job to derive the actual build / manifest / copy matrices.
+
+## Top-level fields
+
+- `architectures` — list of build runner / arch pairs. Each entry:
+  - `id` — short suffix used in intermediate GHCR image tags (e.g. `amd`, `arm`). **Keep stable** to preserve existing tags.
+  - `vm` — `runs-on` runner label (e.g. `ubuntu-latest`, `ubuntu-24.04-arm`).
+  - `platform` — Docker buildx platform string (e.g. `linux/amd64`).
+- `os_variants` — list of OS variants. Each entry:
+  - `id` — version identifier (e.g. `24.04`, `alpine`).
+  - `family` — OS family (e.g. `ubuntu`, `alpine`). Used for image-tag rendering and dispatch-input naming.
+  - `os_arg` — value passed to Docker build-args / used in image tags as the `os_label`.
+  - `dockerfile_base` — path to the OS-specific base Dockerfile.
+  - `default_enabled` — when scheduled / push / tag runs occur (i.e. when no `workflow_dispatch` inputs are provided), the variant is included only if this is `true` on both the OS row and the Node row.
+- `node_versions` — list of Node major versions. Each entry:
+  - `id` — Node major (e.g. `24`).
+  - `default_enabled` — see above.
+  - `extra_platforms` — optional `{ <arch.id>: <platform string> }` appended to that arch's base platform for this Node major.
+  - `exclude_archs` — optional `[<arch.id>, …]` listing archs that should not be built for this Node major.
+
+## Naming conventions
+
+- **Image tags.** For the ubuntu family the node label is rendered as `<node>.x` (e.g. `24.x`); for other families it is `<node>` (e.g. `24`). Arch suffix (`amd`, `arm`) comes from `architectures[].id`.
+- **Dispatch input names.** `<family>_<id_with_-_and_._mapped_to__>_node_<node_id>` when `family != id`, otherwise `<id>_node_<node_id>`. Examples: `ubuntu_24_04_node_24`, `alpine_node_24`. The leading `<family>_` segment exists because GitHub Actions input names must start with a letter — `24_04_…` would be rejected.
+
+## Adding things
+
+- **New OS:** append a row to `os_variants`. Run `node .github/scripts/sync-dispatch-inputs.mjs` to regenerate the `workflow_dispatch.inputs` blocks in the three workflows (the sync workflow enforces this in CI).
+- **New Node major:** append a row to `node_versions`. Same: re-run the sync script.
+- **New arch:** append a row to `architectures`. No script regen needed — arches aren't part of the dispatch input UI.
+
+## Behavior
+
+Scheduled / push / tag runs ignore `workflow_dispatch` inputs and use `default_enabled` from the JSON. On `workflow_dispatch`, the per-`(OS × Node)` checkbox overrides `default_enabled` for that row.

--- a/.github/scripts/sync-dispatch-inputs.mjs
+++ b/.github/scripts/sync-dispatch-inputs.mjs
@@ -7,6 +7,9 @@
 // Usage:
 //   node .github/scripts/sync-dispatch-inputs.mjs            regenerate in place
 //   node .github/scripts/sync-dispatch-inputs.mjs --check    exit 1 if any drift
+//
+// Exit codes: 0 = success / up-to-date, 1 = drift detected (--check only),
+//             2 = BEGIN/END markers missing or malformed in a workflow.
 
 import { readFileSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -89,7 +89,20 @@ jobs:
           ' .github/build-matrix.json)
 
           # Variant matrix: one row per variant (used by manifest + copy jobs).
-          variant_matrix=$(echo "$variants" | jq -c '[ .[] | {os_label, node} ]')
+          # archs is derived from build_matrix so the manifest sources reflect
+          # the architectures actually built (respecting exclude_archs).
+          variant_matrix=$(jq -cn \
+            --argjson variants "$variants" \
+            --argjson build_matrix "$build_matrix" '
+            [ $variants[] as $v |
+              ($v + {
+                archs: [ $build_matrix[]
+                  | select(.os_label == $v.os_label and .node == $v.node)
+                  | .arch ]
+              })
+              | {os_label, node, archs}
+            ]
+          ')
 
           count=$(echo "$variants" | jq 'length')
           if [[ "$count" -gt 0 ]]; then
@@ -152,14 +165,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
 
+      - name: Compute manifest sources
+        id: sources
+        env:
+          ARCHS_JSON: ${{ toJSON(matrix.archs) }}
+          SRC_PREFIX: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}
+          OS: ${{ matrix.os_label }}
+          NODE: ${{ matrix.node }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          srcs=$(jq -r \
+            --arg p "$SRC_PREFIX" --arg o "$OS" --arg n "$NODE" --arg r "$RUN_ID" \
+            '.[] | "\($p):\(.)-\($o)-\($n)-\($r)"' <<<"$ARCHS_JSON")
+          {
+            echo 'value<<EOF'
+            echo "$srcs"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create and push multi-arch manifest to GHCR
         uses: int128/docker-manifest-create-action@v2
         with:
           tags: |
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:latest-${{ matrix.os_label }}-${{ matrix.node }}
           sources: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:amd-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.run_id }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:arm-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.run_id }}
+            ${{ steps.sources.outputs.value }}
 
   copy-to-dockerhub:
     name: Copy ${{ matrix.os_label }} node-${{ matrix.node }} to Docker Hub

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -138,11 +138,12 @@ jobs:
                   | select(.os_label == $v.os_label and .node == $v.node)
                   | .arch ]
               })
+              | select(.archs | length > 0)
               | {os_label, node, suffix, archs}
             ]
           ')
 
-          count=$(echo "$variants" | jq 'length')
+          count=$(echo "$variant_matrix" | jq 'length')
           if [[ "$count" -gt 0 ]]; then
             echo "any_enabled=true" >> "$GITHUB_OUTPUT"
           else
@@ -211,6 +212,7 @@ jobs:
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}
           tags: |
             type=ref,event=branch
+            type=ref,event=tag
             type=sha
           flavor: |
             suffix=${{ matrix.suffix }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,20 @@ jobs:
           ' .github/build-matrix.json)
 
           # Variant matrix: one row per variant (used by manifest + copy jobs).
-          variant_matrix=$(echo "$variants" | jq -c '[ .[] | {os_label, node, suffix} ]')
+          # archs is derived from build_matrix so the manifest sources reflect
+          # the architectures actually built (respecting exclude_archs).
+          variant_matrix=$(jq -cn \
+            --argjson variants "$variants" \
+            --argjson build_matrix "$build_matrix" '
+            [ $variants[] as $v |
+              ($v + {
+                archs: [ $build_matrix[]
+                  | select(.os_label == $v.os_label and .node == $v.node)
+                  | .arch ]
+              })
+              | {os_label, node, suffix, archs}
+            ]
+          ')
 
           count=$(echo "$variants" | jq 'length')
           if [[ "$count" -gt 0 ]]; then
@@ -298,14 +311,31 @@ jobs:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
+      - name: Compute manifest sources
+        id: sources
+        env:
+          ARCHS_JSON: ${{ toJSON(matrix.archs) }}
+          SRC_PREFIX: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}
+          OS: ${{ matrix.os_label }}
+          NODE: ${{ matrix.node }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          srcs=$(jq -r \
+            --arg p "$SRC_PREFIX" --arg o "$OS" --arg n "$NODE" --arg r "$RUN_ID" \
+            '.[] | "\($p):\(.)-\($o)-\($n)-\($r)"' <<<"$ARCHS_JSON")
+          {
+            echo 'value<<EOF'
+            echo "$srcs"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Create and push multi-arch manifest to GHCR
         uses: int128/docker-manifest-create-action@v2
         with:
           tags: |
             ${{ steps.docker_meta.outputs.tags }}
           sources: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:amd-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.run_id }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:arm-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.run_id }}
+            ${{ steps.sources.outputs.value }}
       - name: Save tags to file
         run: |
           mkdir -p /tmp/tags
@@ -363,7 +393,7 @@ jobs:
   housekeeping:
     name: Housekeeping
     needs: [copy-to-dockerhub]
-    if: ${{ always() && needs.copy-to-dockerhub.result == 'success' }}
+    if: ${{ !cancelled() && needs.copy-to-dockerhub.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/sync-dispatch-inputs.yml
+++ b/.github/workflows/sync-dispatch-inputs.yml
@@ -62,6 +62,9 @@ jobs:
           fi
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .github/workflows/*.yml
+          git add \
+            .github/workflows/build-base-image.yml \
+            .github/workflows/build-docker.yml \
+            .github/workflows/release.yml
           git commit -m "chore: sync workflow_dispatch inputs from build-matrix.json [skip ci]"
           git push


### PR DESCRIPTION
## Why

Follow-up to #82 review. Verifies each inline finding against current code, fixes the still-valid ones, and skips the rest with a brief reason.

## Fixed

- **Build-matrix docs.** Moved the long `_comment` body to `.github/docs/build-matrix.md`; the JSON keeps a one-line pointer. Documented `sync-dispatch-inputs.mjs` exit codes (`0` / `1` / `2`) in the header.
- **Archs flow through `variant_matrix`.** `build-base-image.yml` and `release.yml` now carry the per-variant `archs` array (derived from `build_matrix`, respecting `exclude_archs`) and render manifest sources dynamically from `matrix.archs`, instead of a hardcoded `amd` / `arm` pair. This matches the pattern `build-docker.yml` already used.
- **`any_enabled` correctness in `build-docker.yml`.** `variant_matrix` now drops entries whose `archs` list is empty, and `any_enabled` is computed from its length. An `exclude_archs` config that strips every arch for a variant correctly short-circuits manifest / copy.
- **Tag-triggered tagging in `build-docker.yml`.** Added `type=ref,event=tag` to the metadata-action tags so non-`v*` tag-triggered runs produce a tag-derived image tag instead of only branch / sha.
- **Cancellation consistency in `release.yml`.** `housekeeping` is now gated on `!cancelled() && needs.copy-to-dockerhub.result == 'success'` to match the sibling `manifest` and `copy-to-dockerhub` guards.
- **Auto-commit safety in `sync-dispatch-inputs.yml`.** Replaced the `git add .github/workflows/*.yml` glob with an explicit three-file list so unrelated workflow edits cannot ride along.

## Skipped (over-engineering for an internal config)

Per the project's `AGENTS.md` ("Do not add error handling, fallbacks, or validation for scenarios that cannot happen. Trust internal code … Only validate at system boundaries"), the following review items are not applied:

- `try/catch` around `readFileSync` / `JSON.parse` of `build-matrix.json` in the sync script. The matrix is in-repo and maintained alongside the script; Node's default error already includes the path and parse position.
- Structural runtime validation of the parsed matrix object. Same reasoning: a missing / renamed field is a config error, caught immediately with a clear stack.
- A separate `build-matrix.schema.json` plus loader. Adds an external dependency (ajv or similar) and a parallel schema to maintain for what is currently a 25-line internal file.

Happy to add any of these if a maintainer prefers — they're deliberately out of scope here, not blocked.

## Validated

- `node .github/scripts/sync-dispatch-inputs.mjs --check` → all three workflows up to date, exit 0.
- `jq empty .github/build-matrix.json` — valid JSON.
- `python -c "yaml.safe_load(open(f))"` on all four affected workflows — parses cleanly.
- Smoke-tested the new `variant_matrix` jq locally: produces `archs: ["amd","arm"]` per variant; manifest-sources rendering produces the expected `<reg>:<arch>-<os>-<node>-<run_id>` lines.
- `prettier --check` clean on all touched files.

https://claude.ai/code/session_01Tk2LVNF1yHz3SKdCo4EtxF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk2LVNF1yHz3SKdCo4EtxF)_