### PR TITLE
Support manual workflow dispatch for release matrix preparation

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -94,11 +94,12 @@ jobs:
                   | select(.os_label == $v.os_label and .node == $v.node)
                   | .arch ]
               })
+              | select(.archs | length > 0)
               | {os_label, node, archs}
             ]
           ')
 
-          count=$(echo "$variants" | jq 'length')
+          count=$(echo "$variant_matrix" | jq 'length')
           if [[ "$count" -gt 0 ]]; then
             echo "any_enabled=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
   prepare:
     name: Prepare matrices
     needs: [build_and_publish]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       build_matrix: ${{ steps.matrix.outputs.build_matrix }}
@@ -167,18 +167,25 @@ jobs:
         uses: actions/checkout@v6
       - name: Compute matrices
         id: matrix
+        env:
+          # Tag pushes leave inputs empty -> fall back to default_enabled in build-matrix.json.
+          ENABLED_JSON: ${{ toJSON(github.event.inputs) }}
         run: |
           set -euo pipefail
 
           # Cross-product os_variants x node_versions from .github/build-matrix.json,
-          # filtering by default_enabled. The release manifest tag convention puts
-          # ubuntu on the bare semver tags (v2.21.3, latest, v2, v2.21) and adds
-          # '-<family>' for non-ubuntu variants (v2.21.3-alpine, latest-alpine).
-          variants=$(jq -c '
-            .os_variants as $os | .node_versions as $nodes
+          # then filter by the per-row dispatch checkbox (or by default_enabled
+          # for tag runs). The release manifest tag convention puts ubuntu on the
+          # bare semver tags (v2.21.3, latest, v2, v2.21) and adds '-<family>' for
+          # non-ubuntu variants (v2.21.3-alpine, latest-alpine).
+          variants=$(jq -c \
+            --argjson enabled "${ENABLED_JSON:-null}" '
+            (if ($enabled | type) == "object" then $enabled else {} end) as $en
+            | .os_variants as $os | .node_versions as $nodes
             | [ $os[] as $o | $nodes[] as $n |
+                ((if $o.family == $o.id then "" else "\($o.family)_" end) + ($o.id | gsub("[-.]"; "_")) + "_node_" + $n.id) as $key |
                 {
-                  enabled: (if ($o.default_enabled and $n.default_enabled) then "true" else "false" end),
+                  enabled: ($en[$key] // (if ($o.default_enabled and $n.default_enabled) then "true" else "false" end)),
                   family:    $o.family,
                   os_label:  $o.os_arg,
                   node:      (if $o.family == "ubuntu" then "\($n.id).x" else $n.id end),
@@ -220,11 +227,12 @@ jobs:
                   | select(.os_label == $v.os_label and .node == $v.node)
                   | .arch ]
               })
+              | select(.archs | length > 0)
               | {os_label, node, suffix, archs}
             ]
           ')
 
-          count=$(echo "$variants" | jq 'length')
+          count=$(echo "$variant_matrix" | jq 'length')
           if [[ "$count" -gt 0 ]]; then
             echo "any_enabled=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## What problem does this solve?

This change enables the release workflow to be triggered manually via `workflow_dispatch`, allowing maintainers to prepare and test release matrices without requiring a tag push. Previously, the `prepare` job only ran on tag pushes (`refs/tags/`), limiting flexibility in the release process.

The changes also add support for per-variant dispatch checkboxes, allowing fine-grained control over which OS/Node combinations are built during manual workflow runs, while maintaining backward compatibility with tag-based releases (which use `default_enabled` flags).

## How was this tested?

The changes are straightforward workflow configuration updates:
- Added `workflow_dispatch` condition to the `prepare` job trigger
- Extended the jq matrix computation to accept and process dispatch inputs via `ENABLED_JSON` environment variable
- Fixed variable references (`$variants` → `$variant_matrix`) to match actual output names
- Added filtering to exclude variants with no architectures

These are configuration-level changes that will be validated by GitHub Actions when the workflow runs. The logic maintains backward compatibility with existing tag-based releases while adding new dispatch capabilities.

https://claude.ai/code/session_017DRzStpHk4SdjmgSQyMWrm