### PR TITLE
Refresh cached source names after full-config saves

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -545,6 +545,9 @@ module.exports = function (
             res.json('Unable to save configuration change')
             return
           }
+          // Full-config saves can change device descriptions, so refresh
+          // the cached source names like the device routes do.
+          refreshSourceNames()
           res.json('security config saved')
         })
       } else {


### PR DESCRIPTION
## What problem does this solve?

When a full configuration is saved, device descriptions can be changed. However, the cached source names used by device routes were not being refreshed, causing stale device descriptions to be served until the application was restarted.

This fix ensures that `refreshSourceNames()` is called after a successful full-config save, keeping the cached source names in sync with the updated configuration.

## How was this tested?

The change follows the existing pattern used in device routes where `refreshSourceNames()` is called after configuration updates. No additional testing needed as this is a straightforward cache invalidation fix.

https://claude.ai/code/session_018SBdX6xr1Hxn8Dam7N4AKu