### PR TITLE
feat(sources): show human-readable names for WebSocket devices (#88)

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -1751,6 +1751,7 @@ module.exports = function (
           type: 'SOURCEALIASES',
           data: {}
         })
+        refreshSourceNames()
         app.emit('serverAdminEvent', {
           type: 'PRIORITYGROUPS',
           data: []


### PR DESCRIPTION
* feat(sources): show human-readable names for WebSocket devices

WebSocket device sources appear as cryptic refs like
"ws.3d3e48a1-1185-2fe3-c494-1c1a9ee6f41f" across the Dashboard, Data
Browser and Source Priorities. The device's registration description is already 
in the security config, just never surfaced.

Expose a read-only GET /sourceNames map (ws device descriptions merged
with manual aliases) that every authenticated client can read, so
non-admin users see the names too. The map is cached server-side and
rebuilt only when devices or aliases change, never on the per-delta
path. Source-name editing stays admin-only.

* fix(sources): guard /sourceNames and keep map fresh

Address review feedback on the WebSocket device-names change:

- Require read access for GET /sourceNames (authenticated, anonymous
  read-only enabled, or security disabled) so device descriptions are
  not exposed to anonymous clients.
- Broadcast SOURCENAMES on the general serverevent channel instead of
  serverAdminEvent so non-admin clients receive live updates, not just
  the initial fetch.
- Refresh the cached map when /removeSource deletes a source alias.
- Default the /sourceNames fetch response to an empty object so a
  null/empty body cannot break source-label rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds human-readable source names for WebSocket devices and exposes them through a read-only `/sourceNames` map.

It:
- builds source-name mappings from device descriptions plus manual aliases, with aliases taking precedence
- caches the computed map server-side and refreshes it when device, alias, security config, or priority data changes
- broadcasts `SOURCENAMES` updates over `serverevent` so clients stay in sync
- makes `/sourceNames` available to read-access clients while keeping source-name editing admin-only
- updates the Dashboard, Data Browser, and source-label helpers to use friendly names when available
- adds tests for WebSocket ref normalization and source-name resolution behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->