### PR TITLE
feat(sources): show human-readable names for WebSocket devices (#88)

### DIFF
--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -2,11 +2,7 @@ import { useStore, type SignalKStore } from '../store'
 import { fetchAllData } from '../dataFetching'
 
 export type WebSocketStatus =
-  | 'initial'
-  | 'connecting'
-  | 'open'
-  | 'closed'
-  | 'error'
+  'initial' | 'connecting' | 'open' | 'closed' | 'error'
 
 export type DeltaMessageHandler = (message: unknown) => void
 export type StatusChangeHandler = (status: WebSocketStatus) => void
@@ -20,8 +16,7 @@ interface WebSocketServiceState {
 type Listener = () => void
 type ZustandStateSetter = (
   partial:
-    | Partial<SignalKStore>
-    | ((state: SignalKStore) => Partial<SignalKStore>)
+    Partial<SignalKStore> | ((state: SignalKStore) => Partial<SignalKStore>)
 ) => void
 
 export class WebSocketService {

--- a/packages/server-admin-ui/src/store/slices/appSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/appSlice.ts
@@ -407,8 +407,7 @@ export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const clear = (get() as any).clearRetiredSuppressions as
-      | ((s: Record<string, string[]>) => void)
-      | undefined
+      ((s: Record<string, string[]>) => void) | undefined
     clear?.(newcomersByGroup)
   },
 

--- a/packages/server-admin-ui/src/utils/sourceLabels.ts
+++ b/packages/server-admin-ui/src/utils/sourceLabels.ts
@@ -40,8 +40,7 @@ export interface SourceDevice {
 
 export interface SourcesData {
   [connectionOrKey: string]:
-    | SourceDevice
-    | { type?: string; [key: string]: unknown }
+    SourceDevice | { type?: string; [key: string]: unknown }
 }
 
 /**
@@ -166,8 +165,7 @@ export function canonicaliseSourceRef(
   const parsed = parseSourceRef(sourceRef)
   if (!parsed) return sourceRef
   const conn = sourcesData[parsed.connection] as
-    | Record<string, unknown>
-    | undefined
+    Record<string, unknown> | undefined
   if (!conn || typeof conn !== 'object') return sourceRef
   const dev = conn[parsed.src] as SourceDevice | undefined
   if (!dev || typeof dev !== 'object') return sourceRef

--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.tsx
@@ -237,8 +237,7 @@ const DataBrowser: React.FC = () => {
       const connNode = tree[conn] as Record<string, unknown> | undefined
       if (!connNode) return true
       const dev = connNode[addr] as
-        | { n2k?: { manufacturerCode?: string; modelId?: string } }
-        | undefined
+        { n2k?: { manufacturerCode?: string; modelId?: string } } | undefined
       if (!dev) return true
       // For non-N2K sources (no n2k subtree), there's nothing to
       // populate later — don't bother refetching. For N2K, refetch
@@ -705,8 +704,7 @@ const DataBrowser: React.FC = () => {
           continue
         }
         const incomingData = currentData[ctxPrefix || context]?.[realKey] as
-          | PathData
-          | undefined
+          PathData | undefined
         // Server emits livePreferredSources in canonical (canName) form;
         // canonicalise the incoming raw $source before comparing so the
         // dedup decision matches the engine's identity rule.

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -1610,12 +1610,10 @@ module.exports = function (
       const addr = dotIdx === -1 ? '' : sourceRef.slice(dotIdx + 1)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sources = (app.signalk as any)?.sources as
-        | Record<string, Record<string, unknown>>
-        | undefined
+        Record<string, Record<string, unknown>> | undefined
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sourceMeta = (app.signalk as any)?.sourceMeta as
-        | Record<string, unknown>
-        | undefined
+        Record<string, unknown> | undefined
       const inSourceDeltas = Object.prototype.hasOwnProperty.call(
         app.deltaCache.sourceDeltas,
         sourceRef


### PR DESCRIPTION
* feat(sources): show human-readable names for WebSocket devices

WebSocket device sources appear as cryptic refs like
"ws.3d3e48a1-1185-2fe3-c494-1c1a9ee6f41f" across the Dashboard, Data
Browser and Source Priorities. The device's registration description is already 
in the security config, just never surfaced.

Expose a read-only GET /sourceNames map (ws device descriptions merged
with manual aliases) that every authenticated client can read, so
non-admin users see the names too. The map is cached server-side and
rebuilt only when devices or aliases change, never on the per-delta
path. Source-name editing stays admin-only.

* fix(sources): guard /sourceNames and keep map fresh

Address review feedback on the WebSocket device-names change:

- Require read access for GET /sourceNames (authenticated, anonymous
  read-only enabled, or security disabled) so device descriptions are
  not exposed to anonymous clients.
- Broadcast SOURCENAMES on the general serverevent channel instead of
  serverAdminEvent so non-admin clients receive live updates, not just
  the initial fetch.
- Refresh the cached map when /removeSource deletes a source alias.
- Default the /sourceNames fetch response to an empty object so a
  null/empty body cannot break source-label rendering.