### PR TITLE
fix(mdns): log advertisement errors at debug level

### DIFF
--- a/src/mdns.js
+++ b/src/mdns.js
@@ -108,9 +108,12 @@ module.exports = function mdnsResponder(app) {
         type.port
     )
     const ad = new Advertisement(type.type, type.port, options)
+    // mDNS advertisement is best-effort; without a network interface the
+    // library emits errors such as "Timed out getting default route". Log
+    // them at debug level instead of the console so an isolated (offline)
+    // server does not surface a scary, seemingly-fatal error.
     ad.on('error', (err) => {
-      console.log(type.type)
-      console.error(err)
+      debug(`mDNS advertisement error for ${type.type}: ${err.message || err}`)
     })
     ad.start()
     ads.push(ad)

--- a/test/mdns.ts
+++ b/test/mdns.ts
@@ -1,0 +1,143 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'node:events'
+
+type LoadFn = (
+  request: string,
+  parent: NodeModule | null,
+  isMain: boolean
+) => unknown
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Module = require('node:module') as typeof import('node:module') & {
+  _load: LoadFn
+}
+
+const mdnsModulePath = require.resolve('../dist/mdns.js')
+
+class FakeAdvertisement extends EventEmitter {
+  static instances: FakeAdvertisement[] = []
+
+  readonly serviceType: string
+
+  constructor(serviceType: string) {
+    super()
+    this.serviceType = serviceType
+    FakeAdvertisement.instances.push(this)
+  }
+
+  start() {
+    return this
+  }
+
+  stop() {
+    return this
+  }
+}
+
+type App = {
+  config: {
+    settings: Record<string, unknown>
+    name: string
+    version: string
+    getExternalHostname: () => string
+    isExternalSsl: () => boolean
+  }
+  selfId: string
+  interfaces: Record<string, unknown>
+}
+
+describe('mdnsResponder', () => {
+  const originalLoad = Module._load
+  let debugMessages: string[]
+
+  afterEach(() => {
+    Module._load = originalLoad
+    FakeAdvertisement.instances = []
+    delete require.cache[mdnsModulePath]
+  })
+
+  function loadResponder(): (app: App) => unknown {
+    debugMessages = []
+
+    Module._load = ((request, parent, isMain) => {
+      if (request === '@astronautlabs/mdns') {
+        return { Advertisement: FakeAdvertisement }
+      }
+      if (request === './mdnsPatch') {
+        return { patchAstronautLabsMdns: () => {} }
+      }
+      if (request === './ports') {
+        return { getExternalPort: () => 3000 }
+      }
+      if (request === './debug') {
+        return {
+          createDebug: () => (message: unknown) => {
+            if (typeof message === 'string') {
+              debugMessages.push(message)
+            }
+          }
+        }
+      }
+      if (request === 'os') {
+        return { hostname: () => 'testhost' }
+      }
+      return originalLoad(request, parent, isMain)
+    }) as LoadFn
+
+    delete require.cache[mdnsModulePath]
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('../dist/mdns.js') as (app: App) => unknown
+  }
+
+  function makeApp(): App {
+    return {
+      config: {
+        settings: {},
+        name: 'signalk-server',
+        version: '2.0.0',
+        getExternalHostname: () => 'testhost',
+        isExternalSsl: () => false
+      },
+      selfId: 'urn:mrn:signalk:uuid:test',
+      interfaces: {}
+    }
+  }
+
+  it('logs advertisement errors at debug level, not to the console', () => {
+    const logged: unknown[][] = []
+    const originalConsoleError = console.error
+    const originalConsoleLog = console.log
+
+    console.error = (...args: unknown[]) => {
+      logged.push(args)
+    }
+    console.log = (...args: unknown[]) => {
+      logged.push(args)
+    }
+
+    try {
+      const mdnsResponder = loadResponder()
+      mdnsResponder(makeApp())
+
+      expect(FakeAdvertisement.instances).to.have.length(1)
+
+      FakeAdvertisement.instances[0].emit(
+        'error',
+        new Error('Timed out getting default route')
+      )
+
+      expect(logged).to.have.length(0)
+      expect(
+        debugMessages.some(
+          (message) =>
+            message.includes('_http._tcp') &&
+            message.includes('Timed out getting default route')
+        )
+      ).to.equal(true)
+    } finally {
+      console.error = originalConsoleError
+      console.log = originalConsoleLog
+    }
+  })
+})


### PR DESCRIPTION
Without an active network interface the `@astronautlabs/mdns` library emits errors such as "Timed out getting default route". The advertisement error handler logged these via `console.log`/`console.error`, surfacing a scary, seemingly-fatal error on an isolated (offline) server even though mDNS advertisement is a best-effort, non-critical feature.

Log advertisement errors at debug level instead so an offline server starts cleanly.

## How was this tested?

- Added `test/mdns.ts`, which mocks the `@astronautlabs/mdns` `Advertisement` and the `createDebug` factory, emits a "Timed out getting default route" error, and asserts that nothing reaches `console.log`/`console.error` while the diagnostic is still recorded at debug level (message includes the service type and error text).
- Verified the new test fails against a no-op error handler and passes with the fix.
- Ran `npm run build`, `npm run format`, and `eslint` — all clean.