### PR TITLE
Fix debug function mock to include enabled property

### DIFF
--- a/src/mdns.js
+++ b/src/mdns.js
@@ -109,7 +109,10 @@ module.exports = function mdnsResponder(app) {
     )
     const ad = new Advertisement(type.type, type.port, options)
     ad.on('error', (err) => {
-      debug(`mDNS advertisement error for ${type.type}: ${err.message || err}`)
+      debug.enabled &&
+        debug(
+          `mDNS advertisement error for ${type.type}: ${err.message || err}`
+        )
     })
     ad.start()
     ads.push(ad)

--- a/test/mdns.ts
+++ b/test/mdns.ts
@@ -71,10 +71,14 @@ describe('mdnsResponder', () => {
       }
       if (request === './debug') {
         return {
-          createDebug: () => (message: unknown) => {
-            if (typeof message === 'string') {
-              debugMessages.push(message)
+          createDebug: () => {
+            const debug = (message: unknown) => {
+              if (typeof message === 'string') {
+                debugMessages.push(message)
+              }
             }
+            debug.enabled = true
+            return debug
           }
         }
       }


### PR DESCRIPTION
## What problem does this solve?

The debug function mock in tests was not properly implementing the debug library's interface. The actual debug library provides an `enabled` property on debug functions that indicates whether debugging is active. The source code now checks `debug.enabled` before calling debug, but the test mock was missing this property, causing the mock to not match the real implementation.

Additionally, the source code change adds a guard clause to only call debug when enabled, which is a performance optimization that avoids unnecessary string concatenation when debugging is disabled.

## How was this tested?

The test mock has been updated to properly implement the debug function interface with the `enabled` property set to `true`. The existing test suite validates that the mDNS responder correctly handles advertisement errors with the updated debug behavior.

https://claude.ai/code/session_015ViPZUd7iMNyxGeww9PWRa