### PR TITLE
Allow debug logging to be disabled in mdns responder tests

### DIFF
--- a/test/mdns.ts
+++ b/test/mdns.ts
@@ -56,7 +56,7 @@ describe('mdnsResponder', () => {
     delete require.cache[mdnsModulePath]
   })
 
-  function loadResponder(): (app: App) => unknown {
+  function loadResponder(debugEnabled = true): (app: App) => unknown {
     debugMessages = []
 
     Module._load = ((request, parent, isMain) => {
@@ -77,7 +77,7 @@ describe('mdnsResponder', () => {
                 debugMessages.push(message)
               }
             }
-            debug.enabled = true
+            debug.enabled = debugEnabled
             return debug
           }
         }
@@ -143,5 +143,23 @@ describe('mdnsResponder', () => {
       console.error = originalConsoleError
       console.log = originalConsoleLog
     }
+  })
+
+  it('does not log advertisement errors when debug is disabled', () => {
+    const mdnsResponder = loadResponder(false)
+    mdnsResponder(makeApp())
+
+    expect(FakeAdvertisement.instances).to.have.length(1)
+
+    FakeAdvertisement.instances[0].emit(
+      'error',
+      new Error('Timed out getting default route')
+    )
+
+    expect(
+      debugMessages.some((message) =>
+        message.includes('Timed out getting default route')
+      )
+    ).to.equal(false)
   })
 })


### PR DESCRIPTION
## What problem does this solve?

The mdns responder test suite currently always enables debug logging when testing the responder. This change adds the ability to disable debug logging during tests, enabling verification that the responder correctly suppresses debug output when debug mode is disabled.

## How was this tested?

Added a new test case `does not log advertisement errors when debug is disabled` that:
1. Loads the responder with debug disabled (`loadResponder(false)`)
2. Triggers an advertisement error
3. Verifies that the error message does not appear in debug output

The test confirms that debug messages are properly suppressed when the debug flag is disabled.

https://claude.ai/code/session_01BSBb6B3RKDtrvitwRENmXN