### PR TITLE
Add linux-headers to Alpine base Docker image

### DIFF
--- a/docker/Dockerfile_base_alpine
+++ b/docker/Dockerfile_base_alpine
@@ -6,7 +6,7 @@ RUN deluser node 2>/dev/null || true && \
 
 RUN apk add --no-cache \
     sudo git bash \
-    python3 py3-virtualenv py3-pip build-base \
+    python3 py3-virtualenv py3-pip build-base linux-headers \
     procps-ng nano curl libcap-setcap bluez \
  && addgroup -g 991 -S docker \
  && addgroup -g 990 -S i2c \


### PR DESCRIPTION
## What problem does this solve?

The Alpine base Docker image was missing `linux-headers`, which is required for building certain native modules and kernel-dependent packages. This dependency is needed for proper compilation of packages that require kernel headers during the build process.

## How was this tested?

The change is a straightforward dependency addition to the Alpine package manager. CI will verify that the Docker image builds successfully with this additional package included.

https://claude.ai/code/session_01YEKr7V6xh7dASBXQNeo5U2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds Alpine’s `linux-headers` package to the base Docker image.
- Provides SocketCAN headers required to compile native modules such as `canSocket.node`.
- Enables successful `node-gyp` builds for `@canboat/canboatjs`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->